### PR TITLE
Simplify C# sample

### DIFF
--- a/samples/simple-chat/csharp/FunctionApp/Functions.cs
+++ b/samples/simple-chat/csharp/FunctionApp/Functions.cs
@@ -17,39 +17,27 @@ namespace FunctionApp
 {
     public static class Functions
     {
+        [FunctionName("negotiate")]
+        public static IActionResult GetSignalRInfo(
+            [HttpTrigger(AuthorizationLevel.Anonymous)]HttpRequest req, 
+            [SignalRConnectionInfo(HubName = "simplechat")]SignalRConnectionInfo connectionInfo)
+        {
+            return new OkObjectResult(connectionInfo);
+        }
+
         [FunctionName("messages")]
         public static async Task<IActionResult> GetMessages(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post")]HttpRequest req, 
-            [SignalR(HubName = "simplechat")]IAsyncCollector<SignalRMessage> signalRMessages, 
-            ILogger log)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post")]object message, 
+            [SignalR(HubName = "simplechat")]IAsyncCollector<SignalRMessage> signalRMessages)
         {
-            JToken bodyObject;
-            try
-            {
-                bodyObject = JToken.ReadFrom(new JsonTextReader(new StreamReader(req.Body)));
-            }
-            catch (Exception ex)
-            {
-                return new BadRequestObjectResult(ex.ToString());
-            }
-
             await signalRMessages.AddAsync(
                 new SignalRMessage 
                 {
                     Target = "newMessage", 
-                    Arguments = new [] { bodyObject } 
+                    Arguments = new [] { message } 
                 });
 
             return new OkResult();
-        }
-
-        [FunctionName("negotiate")]
-        public static IActionResult GetSignalRInfo(
-            [HttpTrigger(AuthorizationLevel.Anonymous)]HttpRequest req, 
-            [SignalRConnectionInfo(HubName = "simplechat")]SignalRConnectionInfo connectionInfo, 
-            ILogger log)
-        {
-            return new OkObjectResult(connectionInfo);
         }
     }
 }

--- a/samples/simple-chat/csharp/FunctionApp/Functions.cs
+++ b/samples/simple-chat/csharp/FunctionApp/Functions.cs
@@ -26,7 +26,7 @@ namespace FunctionApp
         }
 
         [FunctionName("messages")]
-        public static async Task<IActionResult> GetMessages(
+        public static async Task<IActionResult> SendMessage(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post")]object message, 
             [SignalR(HubName = "simplechat")]IAsyncCollector<SignalRMessage> signalRMessages)
         {

--- a/samples/simple-chat/csharp/FunctionApp/local.settings.sample.json
+++ b/samples/simple-chat/csharp/FunctionApp/local.settings.sample.json
@@ -1,8 +1,8 @@
 {
   "IsEncrypted": false,
   "Values": {
-    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "AzureWebJobsDashboard": "UseDevelopmentStorage=true",
+    "AzureWebJobsStorage": "",
+    "AzureWebJobsDashboard": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "AzureSignalRConnectionString": "<signalr-connection-string>"
   },


### PR DESCRIPTION
- put negotiate function first
- bind directly to body
- remove local storage settings (not needed for HTTP triggers)