### PR TITLE
Add SignalRIAsyncCollectorExtensions to simulate an IHubContext in Azure Functions

### DIFF
--- a/src/SignalRServiceExtension/Bindings/SignalRIAsyncCollectorExtensions.cs
+++ b/src/SignalRServiceExtension/Bindings/SignalRIAsyncCollectorExtensions.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+
+namespace Microsoft.Azure.WebJobs
+{
+    public static class SignalRIAsyncCollectorExtensions
+    {
+        public static IHubClients GetHubClients(this IAsyncCollector<SignalRMessage> collector)
+        {
+            return new CollectorHubClients(collector);
+        }
+
+        public static IUserGroupManager GetHubGroups(this IAsyncCollector<SignalRGroupAction> collector)
+        {
+            return new CollectorUserGroupManager(collector);
+        }
+
+        private class CollectorClientProxy : IClientProxy
+        {
+            private readonly IAsyncCollector<SignalRMessage> _collector;
+            private IEnumerable<SignalRMessage> _destinations;
+
+            public CollectorClientProxy(IAsyncCollector<SignalRMessage> collector, SignalRMessage destination)
+                : this(collector, new[] { destination })
+            {
+            }
+
+            public CollectorClientProxy(IAsyncCollector<SignalRMessage> collector, IEnumerable<SignalRMessage> destinations)
+            {
+                _collector = collector;
+                _destinations = destinations;
+            }
+
+            public async Task SendCoreAsync(string method, object[] args, CancellationToken cancellationToken = default)
+            {
+                foreach (var destination in _destinations)
+                {
+                    await _collector.AddAsync(new SignalRMessage
+                    {
+                        GroupName = destination.GroupName,
+                        UserId = destination.UserId,
+                        Target = method,
+                        Arguments = args,
+                    }, cancellationToken);
+                }
+            }
+        }
+
+        private class CollectorHubClients : IHubClients
+        {
+            private readonly IAsyncCollector<SignalRMessage> _collector;
+
+            public CollectorHubClients(IAsyncCollector<SignalRMessage> collector)
+            {
+                _collector = collector;
+            }
+
+            public IClientProxy All => new CollectorClientProxy(_collector, new SignalRMessage());
+
+            public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IClientProxy Client(string connectionId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IClientProxy Clients(IReadOnlyList<string> connectionIds)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IClientProxy Group(string groupName)
+            {
+                return new CollectorClientProxy(_collector, new SignalRMessage
+                {
+                    GroupName = groupName
+                });
+            }
+
+            public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IClientProxy Groups(IReadOnlyList<string> groupNames)
+            {
+                return new CollectorClientProxy(_collector, groupNames.Select(groupName => new SignalRMessage
+                {
+                    GroupName = groupName
+                }));
+            }
+
+            public IClientProxy User(string userId)
+            {
+                return new CollectorClientProxy(_collector, new SignalRMessage
+                {
+                    UserId = userId
+                });
+            }
+
+            public IClientProxy Users(IReadOnlyList<string> userIds)
+            {
+                return new CollectorClientProxy(_collector, userIds.Select(userId => new SignalRMessage
+                {
+                    UserId = userId 
+                }));
+            }
+        }
+
+        private class CollectorUserGroupManager : IUserGroupManager
+        {
+            private readonly IAsyncCollector<SignalRGroupAction> _collector;
+
+            public CollectorUserGroupManager(IAsyncCollector<SignalRGroupAction> collector)
+            {
+                _collector = collector;
+            }
+
+            public Task AddToGroupAsync(string userId, string groupName, CancellationToken cancellationToken = default)
+            {
+                return _collector.AddAsync(new SignalRGroupAction
+                {
+                    UserId = userId,
+                    GroupName = groupName,
+                    Action = GroupAction.Add
+                }, cancellationToken);
+            }
+
+            public Task RemoveFromGroupAsync(string userId, string groupName, CancellationToken cancellationToken = default)
+            {
+                return _collector.AddAsync(new SignalRGroupAction
+                {
+                    UserId = userId,
+                    GroupName = groupName,
+                    Action = GroupAction.Remove
+                }, cancellationToken);
+            }
+        }
+    }
+}

--- a/test/SignalRServiceExtension.Tests/SignalRAsyncCollectorExtensionsTests.cs
+++ b/test/SignalRServiceExtension.Tests/SignalRAsyncCollectorExtensionsTests.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SignalRServiceExtension.Tests
+{
+    public class SignalRAsyncCollectorExtensionsTests
+    {
+        [Fact]
+        public async Task ClientsAll_CallsSendToAll()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRMessage>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubClients().All.SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
+
+            signalRSenderMock.Verify(c => c.SendToAll("chathub", It.IsAny<SignalRData>()), Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData = (SignalRData)signalRSenderMock.Invocations[0].Arguments[1];
+            Assert.Equal("newMessage", actualData.Target);
+            Assert.Equal("arg1", actualData.Arguments[0]);
+            Assert.Equal("arg2", actualData.Arguments[1]);
+        }
+
+        [Fact]
+        public async Task ClientsUser_CallsSendToUser()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRMessage>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubClients().User("userId1").SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
+
+            signalRSenderMock.Verify(
+                c => c.SendToUser("chathub", "userId1", It.IsAny<SignalRData>()),
+                Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData = (SignalRData)signalRSenderMock.Invocations[0].Arguments[2];
+            Assert.Equal("newMessage", actualData.Target);
+            Assert.Equal("arg1", actualData.Arguments[0]);
+            Assert.Equal("arg2", actualData.Arguments[1]);
+        }
+
+        [Fact]
+        public async Task ClientsUsers_CallsSendToUserForEachUser()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRMessage>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubClients().Users(new[] { "userId1", "userId2" }).SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
+
+            signalRSenderMock.Verify(
+                c => c.SendToUser("chathub", "userId1", It.IsAny<SignalRData>()),
+                Times.Once);
+            signalRSenderMock.Verify(
+                c => c.SendToUser("chathub", "userId2", It.IsAny<SignalRData>()),
+                Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData1 = (SignalRData)signalRSenderMock.Invocations[0].Arguments[2];
+            Assert.Equal("newMessage", actualData1.Target);
+            Assert.Equal("arg1", actualData1.Arguments[0]);
+            Assert.Equal("arg2", actualData1.Arguments[1]);
+            var actualData2 = (SignalRData)signalRSenderMock.Invocations[1].Arguments[2];
+            Assert.Equal("newMessage", actualData2.Target);
+            Assert.Equal("arg1", actualData2.Arguments[0]);
+            Assert.Equal("arg2", actualData2.Arguments[1]);
+        }
+
+        [Fact]
+        public async Task ClientsGroups_CallsSendToGroup()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRMessage>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubClients().Group("group1").SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
+
+            signalRSenderMock.Verify(
+                c => c.SendToGroup("chathub", "group1", It.IsAny<SignalRData>()),
+                Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData = (SignalRData)signalRSenderMock.Invocations[0].Arguments[2];
+            Assert.Equal("newMessage", actualData.Target);
+            Assert.Equal("arg1", actualData.Arguments[0]);
+            Assert.Equal("arg2", actualData.Arguments[1]);
+        }
+
+        [Fact]
+        public async Task ClientsGroup_CallsSendToGroupForEachGroup()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRMessage>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubClients().Groups(new[] { "group1", "group2" }).SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
+
+            signalRSenderMock.Verify(
+                c => c.SendToGroup("chathub", "group1", It.IsAny<SignalRData>()),
+                Times.Once);
+            signalRSenderMock.Verify(
+                c => c.SendToGroup("chathub", "group2", It.IsAny<SignalRData>()),
+                Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData1 = (SignalRData)signalRSenderMock.Invocations[0].Arguments[2];
+            Assert.Equal("newMessage", actualData1.Target);
+            Assert.Equal("arg1", actualData1.Arguments[0]);
+            Assert.Equal("arg2", actualData1.Arguments[1]);
+            var actualData2 = (SignalRData)signalRSenderMock.Invocations[1].Arguments[2];
+            Assert.Equal("newMessage", actualData2.Target);
+            Assert.Equal("arg1", actualData2.Arguments[0]);
+            Assert.Equal("arg2", actualData2.Arguments[1]);
+        }
+
+        [Fact]
+        public async Task AddToGroupAsync_CallsAddUserToGroup()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRGroupAction>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubGroups().AddToGroupAsync("userId1", "group1");
+
+            signalRSenderMock.Verify(
+                c => c.AddUserToGroup("chathub", "userId1", "group1"),
+                Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData = signalRSenderMock.Invocations[0];
+            Assert.Equal("chathub", actualData.Arguments[0]);
+            Assert.Equal("userId1", actualData.Arguments[1]);
+            Assert.Equal("group1", actualData.Arguments[2]);
+        }
+
+        [Fact]
+        public async Task RemoveFromGroupAsync_CallsRemoveUserFromGroup()
+        {
+            var signalRSenderMock = new Mock<IAzureSignalRSender>();
+            var collector = new SignalRAsyncCollector<SignalRGroupAction>(signalRSenderMock.Object, "chathub");
+
+            await collector.GetHubGroups().RemoveFromGroupAsync("userId1", "group1");
+
+            signalRSenderMock.Verify(
+                c => c.RemoveUserFromGroup("chathub", "userId1", "group1"),
+                Times.Once);
+            signalRSenderMock.VerifyNoOtherCalls();
+            var actualData = signalRSenderMock.Invocations[0];
+            Assert.Equal("chathub", actualData.Arguments[0]);
+            Assert.Equal("userId1", actualData.Arguments[1]);
+            Assert.Equal("group1", actualData.Arguments[2]);
+        }
+
+        [Fact]
+        public void NotImplementedClientsMethodsThrowNotImplementedExceptions()
+        {
+            var collector = new SignalRAsyncCollector<SignalRMessage>(Mock.Of<IAzureSignalRSender>(), "chathub");
+            var clients = collector.GetHubClients();
+
+            // A gentle reminder to add tests here for these methods if and when they're added
+            Assert.Throws<NotImplementedException>(() => clients.Client(""));
+            Assert.Throws<NotImplementedException>(() => clients.Clients(new[] { "" }));
+            Assert.Throws<NotImplementedException>(() => clients.AllExcept(new[] { "" }));
+            Assert.Throws<NotImplementedException>(() => clients.GroupExcept("", new[] { "" }));
+        }
+    }
+}


### PR DESCRIPTION
An IHubContext is a little nicer and more familiar than using an IAsyncCollector directly so I created the GetHubClients() and GetHubGroups() extension methods for `IAsyncCollector<SignalRMessage>` and `IAsyncCollector<SignalRGroupAction>` respectively to simulate an IHubContext.

Before:

```C#
await collector.AddAsync(new SignalRMessage
{
    Target = "newMessage",
    Arguments = new[] { "arg1", "arg2" }
});
await collector.AddAsync(new SignalRMessage
{
    UserId = "userId1",
    Target = "newMessage",
    Arguments = new[] { "arg1", "arg2" }
});
await collector.AddAsync(new SignalRMessage
{
    GroupName = "group1",
    Target = "newMessage",
    Arguments = new[] { "arg1", "arg2" }
});
```

After:

```C#
var clients = collector.GetHubClients();
await clients.All.SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
await clients.User("userId1").SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
await clients.Group("group1").SendCoreAsync("newMessage", new[] { "arg1", "arg2" });
```

IHubClients.Client, IHubClients.Clients, IHubClients.AllExcept, and IHubClients.GroupExcept all throw NotImplementedExceptions, but these could all be trivially added once it's supported by SignalRMessage.

Long term it might be nice to unify SignalRMessage and SignalRGroupAction so you could create a full IHubContext from a single IAsyncCollector.