### PR TITLE
Add binding expressions support

### DIFF
--- a/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
+++ b/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             if (parameterNames.Length != parameterNames.Distinct(StringComparer.OrdinalIgnoreCase).Count())
             {
-                throw new ArgumentException("Elements in ParameterNames should be distinct under ignore case.");
+                throw new ArgumentException("Elements in ParameterNames should be ignore case unique.");
             }
         }
 

--- a/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
+++ b/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
@@ -86,8 +86,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                    .AddConverter<JObject, SignalRGroupAction>(input => input.ToObject<SignalRGroupAction>());
 
             // Trigger binding rule
-            context.AddBindingRule<SignalRTriggerAttribute>()
-                .BindToTrigger(new SignalRTriggerBindingProvider(_dispatcher));
+            var triggerBindingRule = context.AddBindingRule<SignalRTriggerAttribute>();
+            triggerBindingRule.AddValidator(ValidateSignalRTriggerAttributeBinding);
+            triggerBindingRule.BindToTrigger(new SignalRTriggerBindingProvider(_dispatcher));
 
             // Non-trigger binding rule
             var signalRConnectionInputBindingProvider = new SignalRConnectionInputBindingProvider(this, securityTokenValidator, signalRConnectionInfoConfigurer);
@@ -140,6 +141,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             if (string.IsNullOrEmpty(connectionString))
             {
                 throw new InvalidOperationException(string.Format(ErrorMessages.EmptyConnectionStringErrorMessageFormat, attributeConnectionStringName));
+            }
+        }
+
+        private void ValidateSignalRTriggerAttributeBinding(SignalRTriggerAttribute attribute, Type type)
+        {
+            ValidateConnectionString(attribute.ConnectionStringSetting,
+                $"{nameof(SignalRTriggerAttribute)}.{nameof(SignalRConnectionInfoAttribute.ConnectionStringSetting)}");
+            ValidateParameterNames(attribute.ParameterNames);
+        }
+
+        private void ValidateParameterNames(string[] parameterNames)
+        {
+            if (parameterNames == null || parameterNames.Length == 0)
+            {
+                return;
+            }
+
+            if (parameterNames.Length != parameterNames.Distinct(StringComparer.OrdinalIgnoreCase).Count())
+            {
+                throw new ArgumentException("Elements in ParameterNames should be distinct under ignore case.");
             }
         }
 

--- a/src/SignalRServiceExtension/Exceptions/SignalRTriggerParametersNotMatchException.cs
+++ b/src/SignalRServiceExtension/Exceptions/SignalRTriggerParametersNotMatchException.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 { 
-    class SignalRTriggerParametersNotMatchException : SignalRTriggerException
+    internal class SignalRTriggerParametersNotMatchException : SignalRTriggerException
     {
         public SignalRTriggerParametersNotMatchException(int excepted, int actual) : base(
             $"The function expected {excepted} parameters but got {actual}")

--- a/src/SignalRServiceExtension/Exceptions/SignalRTriggerParametersNotMatchException.cs
+++ b/src/SignalRServiceExtension/Exceptions/SignalRTriggerParametersNotMatchException.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 { 

--- a/src/SignalRServiceExtension/Exceptions/SignalRTriggerParametersNotMatchException.cs
+++ b/src/SignalRServiceExtension/Exceptions/SignalRTriggerParametersNotMatchException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{ 
+    class SignalRTriggerParametersNotMatchException : SignalRTriggerException
+    {
+        public SignalRTriggerParametersNotMatchException(int excepted, int actual) : base(
+            $"The function expected {excepted} parameters but got {actual}")
+        {
+        }
+    }
+}

--- a/test/SignalRServiceExtension.Tests/GlobalSuppressions.cs
+++ b/test/SignalRServiceExtension.Tests/GlobalSuppressions.cs
@@ -1,7 +1,0 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
-
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "<Pending>", Scope = "member", Target = "~M:SignalRServiceExtension.Tests.SignalRTriggerTests.TestFunction(Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext)")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "<Pending>", Scope = "member", Target = "~M:SignalRServiceExtension.Tests.SignalRTriggerTests.TestFunctionWithTwoStringArgument(Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext,System.String,System.String)")]

--- a/test/SignalRServiceExtension.Tests/GlobalSuppressions.cs
+++ b/test/SignalRServiceExtension.Tests/GlobalSuppressions.cs
@@ -4,3 +4,4 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "<Pending>", Scope = "member", Target = "~M:SignalRServiceExtension.Tests.SignalRTriggerTests.TestFunction(Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext)")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "<Pending>", Scope = "member", Target = "~M:SignalRServiceExtension.Tests.SignalRTriggerTests.TestFunctionWithTwoStringArgument(Microsoft.Azure.WebJobs.Extensions.SignalRService.InvocationContext,System.String,System.String)")]


### PR DESCRIPTION
Leverage Azure Function's powerful binding expressions to make the serverless experience close to traditional SignalR.
The design use trigger attribute `ParameterNames` to tell the trigger what parameters need to be used to bind to `Arguments` in Invocation messages.
Here're some example below.

* C#
```csharp
[FunctionName("SignalRTriggerCSharp")]
public static void Broadcast([SignalRTrigger(HubName = "Hub", Target = "broadcast", ParameterMap = new[] {"arg1", "arg2"})]InvocationContext invocationContext, string arg1, MyType arg2, ILogger log)
{
  logger.LogInformation(context);
}
```

* JavaScript
```js
module.exports = function(context, invocationContext, arg1, arg2) {
    context.log('arg1=%s arg2=%s', arg1, arg2);
    context.done();
};
```
```json
{
    "disabled": false,    
    "bindings": [
        {
            "type": "signalRTrigger",
            "direction": "in",
            "name": "invocationContext",
            "hubName": "Hub",
            "target": "broadcast",
            "parameterNames": [
              "arg1",
              "arg2"
            ]
        }
    ]
}
```