### PR TITLE
Add customer type and conversion for express binding support

### DIFF
--- a/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerAttribute.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerAttribute.cs
@@ -11,6 +11,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     [Binding]
     public class SignalRTriggerAttribute : Attribute
     {
+        public SignalRTriggerAttribute(string hubName, string category, string @event, params string[] parameterNames)
+        {
+            HubName = hubName;
+            Category = category;
+            Event = @event;
+            ParameterNames = parameterNames;
+        }
 
         /// <summary>
         /// Connection string that connect to Azure SignalR Service

--- a/src/SignalRServiceExtension/TriggerBindings/Utils/SignalRTriggerUtils.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/Utils/SignalRTriggerUtils.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private static readonly char[] KeyValueSeparator = { '=' };
         private static readonly char[] QuerySeparator = { '&' };
         private static readonly char[] HeaderSeparator = { ',' };
-        private static readonly string[] ClaimsSeparator = { "= " };
+        private static readonly string[] ClaimsSeparator = { ": " };
 
         public static string GetAccessKey(string connectionString)
         {

--- a/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerTests.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerTests.cs
@@ -44,7 +44,7 @@ namespace SignalRServiceExtension.Tests
             var hub = Guid.NewGuid().ToString();
             var method = Guid.NewGuid().ToString();
             var category = Guid.NewGuid().ToString();
-            var binding = new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute{HubName = hub, Category = category, Event = method}, dispatcher);
+            var binding = new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute(hub, category, method), dispatcher);
             await binding.CreateListenerAsync(listenerFactoryContext);
             Assert.Equal(executor, dispatcher.Executors[(hub, category, method)].Executor);
         }
@@ -106,7 +106,7 @@ namespace SignalRServiceExtension.Tests
         {
             var parameterInfo = this.GetType().GetMethod(functionName, BindingFlags.Instance | BindingFlags.NonPublic).GetParameters()[0];
             var dispatcher = new TestTriggerDispatcher();
-            return new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute{ParameterNames = parameterNames}, dispatcher);
+            return new SignalRTriggerBinding(parameterInfo, new SignalRTriggerAttribute(string.Empty, string.Empty, string.Empty, parameterNames), dispatcher);
         }
 
         internal void TestFunction(InvocationContext context)


### PR DESCRIPTION
When arguments are deserialized from Json/Messagepack payload, it may have different type from the type Functions defined. But it might be convertible。
There're several situations:
*  int/float will be deserialized to long/double no matter in Json or Messagepack. But it can be convert to int/float.
* Customer type
