### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/samples/chat-with-auth/csharp/FunctionApp/.vscode/extensions.json
+++ b/samples/chat-with-auth/csharp/FunctionApp/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }

--- a/samples/simple-chat/csharp/FunctionApp/.vscode/extensions.json
+++ b/samples/simple-chat/csharp/FunctionApp/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }

--- a/samples/simple-chat/js/functionapp/.vscode/extensions.json
+++ b/samples/simple-chat/js/functionapp/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "ms-azuretools.vscode-azurefunctions",
-    "ms-vscode.csharp"
+    "ms-dotnettools.csharp"
   ]
 }


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)