### PR TITLE
fix Microsoft.AspNetCore.SignalR.Protocols.MessagePack 3.x breaking change

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -14,7 +14,7 @@
     <MessagePackPackageVersion>1.9.11</MessagePackPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <SystemMemoryPackageVersion>4.5.3</SystemMemoryPackageVersion>
-    <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>3.1.2</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
+    <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>1.1.5</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
 
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />


### PR DESCRIPTION
Microsoft.AspNetCore.SignalR.Protocols.MessagePack 3.x uses microsoft.extensions.configuration.abstractions 3.x, break with function runtime for netstand2.x and netcoreapp2.x