### PR TITLE
Fixes #112 and cleans up readers and stream

### DIFF
--- a/src/Microsoft.Azure.SignalR.Serverless.Protocols/JsonServerlessProtocol.cs
+++ b/src/Microsoft.Azure.SignalR.Serverless.Protocols/JsonServerlessProtocol.cs
@@ -19,30 +19,41 @@ namespace Microsoft.Azure.SignalR.Serverless.Protocols
 
         public bool TryParseMessage(ref ReadOnlySequence<byte> input, out ServerlessMessage message)
         {
-            var textReader = new JsonTextReader(new StreamReader(new ReadOnlySequenceStream(input)));
-            var jObject = JObject.Load(textReader);
-            if (jObject.TryGetValue(TypePropertyName, StringComparison.OrdinalIgnoreCase, out var token))
+            using var inputStream = new ReadOnlySequenceStream(input);
+            using var streamReader = new StreamReader(inputStream);
+            var textReader = new JsonTextReader(streamReader);
+
+            try
             {
-                var type = token.Value<int>();
-                switch (type)
+                var jObject = JObject.Load(textReader);
+                if (jObject.TryGetValue(TypePropertyName, StringComparison.OrdinalIgnoreCase, out var token))
                 {
-                    case ServerlessProtocolConstants.InvocationMessageType:
-                        message = SafeParseMessage<InvocationMessage>(jObject);
-                        break;
-                    case ServerlessProtocolConstants.OpenConnectionMessageType:
-                        message = SafeParseMessage<OpenConnectionMessage>(jObject);
-                        break;
-                    case ServerlessProtocolConstants.CloseConnectionMessageType:
-                        message = SafeParseMessage<CloseConnectionMessage>(jObject);
-                        break;
-                    default:
-                        message = null;
-                        break;
+                    var type = token.Value<int>();
+                    switch (type)
+                    {
+                        case ServerlessProtocolConstants.InvocationMessageType:
+                            message = SafeParseMessage<InvocationMessage>(jObject);
+                            break;
+                        case ServerlessProtocolConstants.OpenConnectionMessageType:
+                            message = SafeParseMessage<OpenConnectionMessage>(jObject);
+                            break;
+                        case ServerlessProtocolConstants.CloseConnectionMessageType:
+                            message = SafeParseMessage<CloseConnectionMessage>(jObject);
+                            break;
+                        default:
+                            message = null;
+                            break;
+                    }
                 }
+                else
+                    message = null;
+
                 return message != null;
             }
-            message = null;
-            return false;
+            finally
+            {
+                textReader.Close();
+            }
         }
 
         private ServerlessMessage SafeParseMessage<T>(JObject jObject) where T : ServerlessMessage


### PR DESCRIPTION
Fixes #112 by ensuring `StreamReader` and `Stream` is disposed as well as closing the `JsonTextReader`. The current implementation of `Close` in the `JsonTextReader` disposes the passed `StreamReader` but that should be the callers concerns in my opinion. Could do just a call to `Close` if that's preferred.