### PR TITLE
Implements Type in SignalRValueProvider

### DIFF
--- a/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SecurityTokenValidationInputBinding.cs
+++ b/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SecurityTokenValidationInputBinding.cs
@@ -30,12 +30,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 throw new NotSupportedException($"Argument {nameof(HttpRequest)} is null. {nameof(SecurityTokenValidationAttribute)} must work with HttpTrigger.");
             }
 
-            if (securityTokenValidator == null)
-            {
-                return Task.FromResult((IValueProvider)new SignalRValueProvider(null));
-            }
-
-            return Task.FromResult((IValueProvider)new SignalRValueProvider(securityTokenValidator.ValidateToken(request)));
+            return Task.FromResult(SignalRValueProvider.Create(
+                securityTokenValidator?.ValidateToken(request)));
         }
 
         public Task<IValueProvider> BindAsync(BindingContext context)

--- a/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SignalRConnectionInputBinding.cs
+++ b/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SignalRConnectionInputBinding.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 var info = azureSignalRClient.GetClientConnectionInfo(attrResolved.UserId, attrResolved.IdToken,
                     attrResolved.ClaimTypeList);
-                return Task.FromResult((IValueProvider)new SignalRValueProvider(info));
+                return Task.FromResult(SignalRValueProvider.Create(info));
             }
 
             var request = bindingData[HttpRequestName] as HttpRequest;
@@ -46,14 +46,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             if (tokenResult.Status != SecurityTokenStatus.Valid)
             {
-                return Task.FromResult((IValueProvider)new SignalRValueProvider(null));
+                return Task.FromResult((IValueProvider)SignalRNullValueProvider<SignalRConnectionInfo>.Instance);
             }
 
             if (signalRConnectionInfoConfigurer == null)
             {
                 var info = azureSignalRClient.GetClientConnectionInfo(attrResolved.UserId, attrResolved.IdToken,
                     attrResolved.ClaimTypeList);
-                return Task.FromResult((IValueProvider)new SignalRValueProvider(info));
+                return Task.FromResult(SignalRValueProvider.Create(info));
             }
 
             var signalRConnectionDetail = new SignalRConnectionDetail
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             signalRConnectionInfoConfigurer.Configure(tokenResult, request, signalRConnectionDetail);
             var customizedInfo = azureSignalRClient.GetClientConnectionInfo(signalRConnectionDetail.UserId,
                 signalRConnectionDetail.Claims);
-            return Task.FromResult((IValueProvider)new SignalRValueProvider(customizedInfo));
+            return Task.FromResult(SignalRValueProvider.Create(customizedInfo));
         }
     }
 }

--- a/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SignalRNullValueProvider.cs
+++ b/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SignalRNullValueProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService.Internal;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal class SignalRNullValueProvider<T> : IValueProvider
+    {
+        internal static readonly SignalRNullValueProvider<T> Instance = new SignalRNullValueProvider<T>();
+
+        public Type Type { get; }
+
+        private SignalRNullValueProvider()
+            => Type = typeof(T);
+
+        public Task<object> GetValueAsync()
+            => NullObjectTask.Result;
+
+        public string ToInvokeString()
+            => null;
+    }
+}

--- a/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SignalRValueProvider.cs
+++ b/src/SignalRServiceExtension/Bindings/SignalRInputBindings/SignalRValueProvider.cs
@@ -9,23 +9,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal class SignalRValueProvider : IValueProvider
     {
-        private object value;
+        private readonly object value;
 
-        public SignalRValueProvider(object value)
+        private SignalRValueProvider(object value, Type valueType)
         {
             this.value = value;
+
+            Type = valueType;
         }
 
-        public Task<object> GetValueAsync()
-        {
-            return Task.FromResult(value);
-        }
-
-        public string ToInvokeString()
-        {
-            return value?.ToString();
-        }
+        internal static IValueProvider Create<T>(T value) where T : class
+            => value == null
+                ? (IValueProvider) SignalRNullValueProvider<T>.Instance
+                : new SignalRValueProvider(value, typeof(T));
 
         public Type Type { get; }
+
+        public Task<object> GetValueAsync()
+            => Task.FromResult(value);
+
+        public string ToInvokeString()
+            => value.ToString();
     }
 }

--- a/src/SignalRServiceExtension/Internal/NullObjectTask.cs
+++ b/src/SignalRServiceExtension/Internal/NullObjectTask.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Internal
+{
+    internal static class NullObjectTask
+    {
+        internal static readonly Task<object> Result = Task.FromResult<object>(null);
+    }
+}


### PR DESCRIPTION
Implements the `Type` property in the `SignalRValueProvider` as it currently was left unassigned, or was this by design? Also introduces a specific `SignalRNullValueProvider` and unifies the creation of it using a simple factory method.

Didn't add the type checks that e.g. the `ObjectValueProvider` does as the factory method ensures the type is correct.