### PR TITLE
Fix SignalR Trigger makes whole function app down in Azure Static Web Apps

### DIFF
--- a/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
+++ b/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
@@ -80,10 +80,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 logger.LogInformation($"Registered SignalR trigger Endpoint = {url?.GetLeftPart(UriPartial.Path)}");
                 triggerEnabled = true;
             }
-            catch(Exception ex)
+            catch
             {
-                logger.LogWarning("SignalR trigger requires 'AzureWebJobsStorage' connection string being set. All SignalR trigger functions will be suppressed. " + 
-                    $"It's expected if you're using Azure Static Web Apps but not in other secnarios. {ex}");
+                logger.LogInformation("SignalR input and output bindings are enabled. " +
+                                      "To use the SignalR trigger, please set 'AzureWebJobsStorage' to a valid connection string.");
             }
             
             context.AddConverter<string, JObject>(JObject.FromObject)

--- a/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
+++ b/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
@@ -73,17 +73,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             StaticServiceHubContextStore.ServiceManagerStore = new ServiceManagerStore(options.AzureSignalRServiceTransportType, configuration, loggerFactory);
 
-            bool triggerEnabled = false;
+            Exception webhookException = null;
             try
             {
                 var url = context.GetWebhookHandler();
                 logger.LogInformation($"Registered SignalR trigger Endpoint = {url?.GetLeftPart(UriPartial.Path)}");
-                triggerEnabled = true;
             }
-            catch
+            catch (Exception ex)
             {
-                logger.LogInformation("SignalR input and output bindings are enabled. " +
-                                      "To use the SignalR trigger, please set 'AzureWebJobsStorage' to a valid connection string.");
+                webhookException = ex;
             }
             
             context.AddConverter<string, JObject>(JObject.FromObject)
@@ -94,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             // Trigger binding rule
             var triggerBindingRule = context.AddBindingRule<SignalRTriggerAttribute>();
             triggerBindingRule.AddConverter<InvocationContext, JObject>(JObject.FromObject);
-            triggerBindingRule.BindToTrigger<InvocationContext>(new SignalRTriggerBindingProvider(_dispatcher, nameResolver, options, triggerEnabled));
+            triggerBindingRule.BindToTrigger<InvocationContext>(new SignalRTriggerBindingProvider(_dispatcher, nameResolver, options, webhookException));
                         
             // Non-trigger binding rule
             var signalRConnectionInfoAttributeRule = context.AddBindingRule<SignalRConnectionInfoAttribute>();

--- a/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerBindingProvider.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerBindingProvider.cs
@@ -18,14 +18,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private readonly ISignalRTriggerDispatcher _dispatcher;
         private readonly INameResolver _nameResolver;
         private readonly SignalROptions _options;
-        private readonly bool _enabled;
+        private readonly Exception _webhookException;
 
-        public SignalRTriggerBindingProvider(ISignalRTriggerDispatcher dispatcher, INameResolver nameResolver, SignalROptions options, bool enabled)
+        public SignalRTriggerBindingProvider(ISignalRTriggerDispatcher dispatcher, INameResolver nameResolver, SignalROptions options, Exception webhookException)
         {
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
             _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            _enabled = enabled;
+            _webhookException = webhookException;
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            if (!_enabled)
+            if (_webhookException != null)
             {
-                throw new NotSupportedException("SignalR trigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid.");
+                throw new NotSupportedException($"SignalR trigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid. {_webhookException}");
             }
 
             var resolvedAttribute = GetParameterResolvedAttribute(attribute, parameterInfo);

--- a/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerBindingProvider.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerBindingProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             if (!_enabled)
             {
-                throw new InvalidOperationException("SignalR Trigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid.");
+                throw new NotSupportedException("SignalR trigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid.");
             }
 
             var resolvedAttribute = GetParameterResolvedAttribute(attribute, parameterInfo);

--- a/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerBindingProvider.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/SignalRTriggerBindingProvider.cs
@@ -18,12 +18,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private readonly ISignalRTriggerDispatcher _dispatcher;
         private readonly INameResolver _nameResolver;
         private readonly SignalROptions _options;
+        private readonly bool _enabled;
 
-        public SignalRTriggerBindingProvider(ISignalRTriggerDispatcher dispatcher, INameResolver nameResolver, SignalROptions options)
+        public SignalRTriggerBindingProvider(ISignalRTriggerDispatcher dispatcher, INameResolver nameResolver, SignalROptions options, bool enabled)
         {
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
             _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _enabled = enabled;
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -39,6 +41,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 return Task.FromResult<ITriggerBinding>(null);
             }
+
+            if (!_enabled)
+            {
+                throw new InvalidOperationException("SignalR Trigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid.");
+            }
+
             var resolvedAttribute = GetParameterResolvedAttribute(attribute, parameterInfo);
             ValidateSignalRTriggerAttributeBinding(resolvedAttribute);
             

--- a/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
@@ -86,7 +86,7 @@ namespace SignalRServiceExtension.Tests
             var bindingProvider = CreateBindingProvider(new Exception());
             var parameter = typeof(TestConnectedServerlessHub).GetMethod(nameof(TestConnectedServerlessHub.OnConnected), BindingFlags.Instance | BindingFlags.NonPublic).GetParameters()[0];
             var context = new TriggerBindingProviderContext(parameter, default);
-            Assert.ThrowsAsync<Exception>(() => bindingProvider.TryCreateAsync(context));
+            Assert.ThrowsAsync<NotSupportedException>(() => bindingProvider.TryCreateAsync(context));
         }
 
         private SignalRTriggerBindingProvider CreateBindingProvider(Exception exception = null)

--- a/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
@@ -82,7 +82,7 @@ namespace SignalRServiceExtension.Tests
         private SignalRTriggerBindingProvider CreateBindingProvider()
         {
             var dispatcher = new TestTriggerDispatcher();
-            return new SignalRTriggerBindingProvider(dispatcher, new DefaultNameResolver(new ConfigurationSection(new ConfigurationRoot(new List<IConfigurationProvider>()), String.Empty)), new SignalROptions());
+            return new SignalRTriggerBindingProvider(dispatcher, new DefaultNameResolver(new ConfigurationSection(new ConfigurationRoot(new List<IConfigurationProvider>()), String.Empty)), new SignalROptions(), true);
         }
 
         public class TestServerlessHub : ServerlessHub

--- a/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SignalRServiceExtension.Tests.Utils;
@@ -79,10 +80,19 @@ namespace SignalRServiceExtension.Tests
             Assert.ThrowsAny<Exception>(() => bindingProvider.GetParameterResolvedAttribute(attribute, parameter));
         }
 
-        private SignalRTriggerBindingProvider CreateBindingProvider()
+        [Fact]
+        public void WebhookFailedTest()
+        {
+            var bindingProvider = CreateBindingProvider(new Exception());
+            var parameter = typeof(TestConnectedServerlessHub).GetMethod(nameof(TestConnectedServerlessHub.OnConnected), BindingFlags.Instance | BindingFlags.NonPublic).GetParameters()[0];
+            var context = new TriggerBindingProviderContext(parameter, default);
+            Assert.ThrowsAsync<Exception>(() => bindingProvider.TryCreateAsync(context));
+        }
+
+        private SignalRTriggerBindingProvider CreateBindingProvider(Exception exception = null)
         {
             var dispatcher = new TestTriggerDispatcher();
-            return new SignalRTriggerBindingProvider(dispatcher, new DefaultNameResolver(new ConfigurationSection(new ConfigurationRoot(new List<IConfigurationProvider>()), String.Empty)), new SignalROptions(), true);
+            return new SignalRTriggerBindingProvider(dispatcher, new DefaultNameResolver(new ConfigurationSection(new ConfigurationRoot(new List<IConfigurationProvider>()), String.Empty)), new SignalROptions(), exception);
         }
 
         public class TestServerlessHub : ServerlessHub


### PR DESCRIPTION
In Azure Static Web Apps, there's no storage account that required by webhook provider. As Azure Static Web Apps doesn't support all trigger's exception Http Trigger, we just disable SignalR Trigger in such case.