### PR TITLE
Get the origin value of ConnectionStringSetting of non-trigging binding

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <MicrosoftAzureSignalRManagement>1.4.1</MicrosoftAzureSignalRManagement>
+    <MicrosoftAzureSignalRManagement>1.6.2</MicrosoftAzureSignalRManagement>
     <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>
@@ -15,7 +15,8 @@
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <SystemMemoryPackageVersion>4.5.3</SystemMemoryPackageVersion>
     <MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>1.1.5</MicrosoftAspNetCoreSignalRProtocolsMessagePackPackageVersion>
-
+    <SystemIdentityModelTokensJwtVersion>5.5.0</SystemIdentityModelTokensJwtVersion>
+    <MicrosoftAspNetCoreSignalRPackageVersion>1.0.0</MicrosoftAspNetCoreSignalRPackageVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <MicrosoftAzureSignalRManagement>1.6.2</MicrosoftAzureSignalRManagement>
+    <MicrosoftAzureSignalRManagement>1.6.2-preview1-10689</MicrosoftAzureSignalRManagement>
     <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>

--- a/src/SignalRServiceExtension/Client/AzureSignalRClient.cs
+++ b/src/SignalRServiceExtension/Client/AzureSignalRClient.cs
@@ -25,21 +25,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             "nbf"  // Not Before claim. Added by default. It is not validated by service.
         };
         private readonly IServiceManagerStore serviceManagerStore;
-        private readonly string connectionString;
+        private readonly string connectionStringKey;
 
         public string HubName { get; }
 
-        internal AzureSignalRClient(IServiceManagerStore serviceManagerStore, string connectionString, string hubName)
+        internal AzureSignalRClient(IServiceManagerStore serviceManagerStore, string connectionStringKey, string hubName)
         {
             this.serviceManagerStore = serviceManagerStore;
             this.HubName = hubName;
-            this.connectionString = connectionString;
+            this.connectionStringKey = connectionStringKey;
         }
 
         public SignalRConnectionInfo GetClientConnectionInfo(string userId, string idToken, string[] claimTypeList)
         {
             var customerClaims = GetCustomClaims(idToken, claimTypeList);
-            var serviceManager = serviceManagerStore.GetOrAddByConnectionString(connectionString).ServiceManager;
+            var serviceManager = serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).ServiceManager;
 
             return new SignalRConnectionInfo
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         public SignalRConnectionInfo GetClientConnectionInfo(string userId, IList<Claim> claims)
         {
-            var serviceManager = serviceManagerStore.GetOrAddByConnectionString(connectionString).ServiceManager;
+            var serviceManager = serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).ServiceManager;
             return new SignalRConnectionInfo
             {
                 Url = serviceManager.GetClientEndpoint(HubName),
@@ -81,13 +81,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         public async Task SendToAll(SignalRData data)
         {
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.Clients.All.SendCoreAsync(data.Target, data.Arguments);
         }
 
         public async Task SendToConnection(string connectionId, SignalRData data)
         {
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.Clients.Client(connectionId).SendCoreAsync(data.Target, data.Arguments);
         }
 
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(userId)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.Clients.User(userId).SendCoreAsync(data.Target, data.Arguments);
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(groupName)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.Clients.Group(groupName).SendCoreAsync(data.Target, data.Arguments);
         }
 
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(groupName)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.UserGroups.AddToGroupAsync(userId, groupName);
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(groupName)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.UserGroups.RemoveFromGroupAsync(userId, groupName);
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(userId)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.UserGroups.RemoveFromAllGroupsAsync(userId);
         }
 
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(groupName)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.Groups.AddToGroupAsync(connectionId, groupName);
         }
 
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 throw new ArgumentException($"{nameof(groupName)} cannot be null or empty");
             }
-            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionString(connectionString).GetAsync(HubName);
+            var serviceHubContext = await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName);
             await serviceHubContext.Groups.RemoveFromGroupAsync(connectionId, groupName);
         }
 

--- a/src/SignalRServiceExtension/Config/IServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/IServiceManagerStore.cs
@@ -5,8 +5,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal interface IServiceManagerStore
     {
-        IServiceHubContextStore GetOrAddByConfigurationKey(string configurationKey);
-
-        IServiceHubContextStore GetOrAddByConnectionString(string connectionString);
+        IServiceHubContextStore GetOrAddByConnectionStringKey(string connectionStringKey);
     }
 }

--- a/src/SignalRServiceExtension/Config/OptionsSetup.cs
+++ b/src/SignalRServiceExtension/Config/OptionsSetup.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal class OptionsSetup : IConfigureOptions<ServiceManagerOptions>, IOptionsChangeTokenSource<ServiceManagerOptions>
+    {
+        private readonly IConfiguration _configuration;
+        private readonly string _ConnectionStringKey;
+        private readonly ILogger _logger;
+
+        public OptionsSetup(IConfiguration configuration, ILoggerFactory loggerFactory, string connectionStringKey)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            if (string.IsNullOrWhiteSpace(connectionStringKey))
+            {
+                throw new ArgumentException($"'{nameof(connectionStringKey)}' cannot be null or whitespace", nameof(connectionStringKey));
+            }
+
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _ConnectionStringKey = connectionStringKey;
+            _logger = loggerFactory.CreateLogger<OptionsSetup>();
+        }
+
+        public string Name => Options.DefaultName;
+
+        public void Configure(ServiceManagerOptions options)
+        {
+            options.ConnectionString = _configuration[_ConnectionStringKey];
+            var serviceTransportTypeStr = _configuration[Constants.ServiceTransportTypeName];
+            if (Enum.TryParse<ServiceTransportType>(serviceTransportTypeStr, out var transport))
+            {
+                options.ServiceTransportType = transport;
+            }
+            else
+            {
+                options.ServiceTransportType = ServiceTransportType.Transient;
+                _logger.LogWarning($"Unsupported service transport type: {serviceTransportTypeStr}. Use default {ServiceTransportType.Transient} instead.");
+            }
+            options.ConnectionCount = 3;//make connection more stable
+        }
+
+        public IChangeToken GetChangeToken()
+        {
+            return _configuration.GetReloadToken();
+        }
+    }
+}

--- a/src/SignalRServiceExtension/Config/OptionsSetup.cs
+++ b/src/SignalRServiceExtension/Config/OptionsSetup.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
     internal class OptionsSetup : IConfigureOptions<ServiceManagerOptions>, IOptionsChangeTokenSource<ServiceManagerOptions>
     {
-        private readonly IConfiguration _configuration;
-        private readonly string _ConnectionStringKey;
-        private readonly ILogger _logger;
+        private readonly IConfiguration configuration;
+        private readonly string connectionStringKey;
+        private readonly ILogger logger;
 
         public OptionsSetup(IConfiguration configuration, ILoggerFactory loggerFactory, string connectionStringKey)
         {
@@ -28,17 +28,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 throw new ArgumentException($"'{nameof(connectionStringKey)}' cannot be null or whitespace", nameof(connectionStringKey));
             }
 
-            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _ConnectionStringKey = connectionStringKey;
-            _logger = loggerFactory.CreateLogger<OptionsSetup>();
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            this.connectionStringKey = connectionStringKey;
+            logger = loggerFactory.CreateLogger<OptionsSetup>();
         }
 
         public string Name => Options.DefaultName;
 
         public void Configure(ServiceManagerOptions options)
         {
-            options.ConnectionString = _configuration[_ConnectionStringKey];
-            var serviceTransportTypeStr = _configuration[Constants.ServiceTransportTypeName];
+            options.ConnectionString = configuration[connectionStringKey];
+            var serviceTransportTypeStr = configuration[Constants.ServiceTransportTypeName];
             if (Enum.TryParse<ServiceTransportType>(serviceTransportTypeStr, out var transport))
             {
                 options.ServiceTransportType = transport;
@@ -46,14 +46,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             else
             {
                 options.ServiceTransportType = ServiceTransportType.Transient;
-                _logger.LogWarning($"Unsupported service transport type: {serviceTransportTypeStr}. Use default {ServiceTransportType.Transient} instead.");
+                logger.LogWarning($"Unsupported service transport type: {serviceTransportTypeStr}. Use default {ServiceTransportType.Transient} instead.");
             }
-            options.ConnectionCount = 3;//make connection more stable
+            //make connection more stable
+            options.ConnectionCount = 3;
         }
 
         public IChangeToken GetChangeToken()
         {
-            return _configuration.GetReloadToken();
+            return configuration.GetReloadToken();
         }
     }
 }

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -41,13 +41,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         private IServiceHubContextStore CreateHubContextStore(string connectionStringKey)
         {
-<<<<<<< HEAD
-            return new ServiceManagerBuilder().WithOptions(o =>
-            {
-                o.ConnectionString = connectionString;
-                o.ServiceTransportType = transportType;
-            }).WithCallingAssembly().Build();
-=======
             return new ServiceCollection().AddSignalRServiceManager()
                 .WithAssembly(Assembly.GetExecutingAssembly())
                 .SetupOptions<ServiceManagerOptions,OptionsSetup>(new OptionsSetup(configuration, loggerFactory, connectionStringKey))
@@ -63,7 +56,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 .AddSingleton<IServiceHubContextStore, ServiceHubContextStore>()
                 .BuildServiceProvider()
                 .GetRequiredService<IServiceHubContextStore>();
->>>>>>> 5d38c1a (invokes SDK in DI way)
         }
     }
 }

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
@@ -12,7 +15,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     internal class ServiceManagerStore : IServiceManagerStore
     {
         private readonly ILoggerFactory loggerFactory;
-        private readonly ServiceTransportType transportType;
         private readonly IConfiguration configuration;
         private readonly ConcurrentDictionary<string, IServiceHubContextStore> store = new ConcurrentDictionary<string, IServiceHubContextStore>();
 
@@ -20,50 +22,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             this.loggerFactory = loggerFactory;
             this.configuration = configuration;
-            var serviceTransportTypeStr = configuration[Constants.ServiceTransportTypeName];
-            var logger = loggerFactory.CreateLogger<ServiceManagerStore>();
-            if (Enum.TryParse<ServiceTransportType>(serviceTransportTypeStr, out var transport))
+        }
+
+        public IServiceHubContextStore GetOrAddByConnectionStringKey(string connectionStringKey)
+        {
+            if (string.IsNullOrWhiteSpace(connectionStringKey))
             {
-                this.transportType = transport;
+                throw new ArgumentException($"'{nameof(connectionStringKey)}' cannot be null or whitespace", nameof(connectionStringKey));
             }
-            else
-            {
-                this.transportType = ServiceTransportType.Transient;
-                logger.LogWarning($"Unsupported service transport type: {serviceTransportTypeStr}. Use default {transportType} instead.");
-            }
+            return store.GetOrAdd(connectionStringKey, CreateHubContextStore);
         }
 
-        public IServiceHubContextStore GetOrAddByConfigurationKey(string configurationKey)
+        //test only
+        public IServiceHubContextStore GetByConfigurationKey(string connectionStringKey)
         {
-            string connectionString = configuration[configurationKey];
-            return GetOrAddByConnectionString(connectionString);
+            return store.ContainsKey(connectionStringKey) ? store[connectionStringKey] : null;
         }
 
-        public IServiceHubContextStore GetOrAddByConnectionString(string connectionString)
+        private IServiceHubContextStore CreateHubContextStore(string connectionStringKey)
         {
-            return store.GetOrAdd(connectionString, CreateHubContextStore);
-        }
-
-        // test only
-        public IServiceHubContextStore GetByConfigurationKey(string configurationKey)
-        {
-            string connectionString = configuration[configurationKey];
-            return store.ContainsKey(connectionString) ? store[connectionString] : null;
-        }
-
-        private IServiceHubContextStore CreateHubContextStore(string connectionString)
-        {
-            var serviceManager = CreateServiceManager(connectionString);
-            return new ServiceHubContextStore(serviceManager, loggerFactory);
-        }
-
-        private IServiceManager CreateServiceManager(string connectionString)
-        {
+<<<<<<< HEAD
             return new ServiceManagerBuilder().WithOptions(o =>
             {
                 o.ConnectionString = connectionString;
                 o.ServiceTransportType = transportType;
             }).WithCallingAssembly().Build();
+=======
+            return new ServiceCollection().AddSignalRServiceManager()
+                .WithAssembly(Assembly.GetExecutingAssembly())
+                .SetupOptions<ServiceManagerOptions,OptionsSetup>(new OptionsSetup(configuration, loggerFactory, connectionStringKey))
+                .PostConfigure<ServiceManagerOptions>(o =>
+                {
+                    if (string.IsNullOrWhiteSpace(o.ConnectionString))
+                    {
+                        throw new InvalidOperationException(ErrorMessages.EmptyConnectionStringErrorMessageFormat);
+                    }
+                })
+                .AddSingleton(loggerFactory)
+                .AddSingleton(configuration)
+                .AddSingleton<IServiceHubContextStore, ServiceHubContextStore>()
+                .BuildServiceProvider()
+                .GetRequiredService<IServiceHubContextStore>();
+>>>>>>> 5d38c1a (invokes SDK in DI way)
         }
     }
 }

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             return new ServiceCollection().AddSignalRServiceManager()
                 .WithAssembly(Assembly.GetExecutingAssembly())
-                .SetupOptions<ServiceManagerOptions,OptionsSetup>(new OptionsSetup(configuration, loggerFactory, connectionStringKey))
+                .SetupOptions<ServiceManagerOptions, OptionsSetup>(new OptionsSetup(configuration, loggerFactory, connectionStringKey))
                 .PostConfigure<ServiceManagerOptions>(o =>
                 {
                     if (string.IsNullOrWhiteSpace(o.ConnectionString))

--- a/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
+++ b/src/SignalRServiceExtension/Config/SignalRConfigProvider.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
@@ -89,14 +87,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                         
             // Non-trigger binding rule
             var signalRConnectionInfoAttributeRule = context.AddBindingRule<SignalRConnectionInfoAttribute>();
-            signalRConnectionInfoAttributeRule.AddValidator(ValidateSignalRConnectionInfoAttributeBinding);
             signalRConnectionInfoAttributeRule.Bind(inputBindingProvider);
 
             var securityTokenValidationAttributeRule = context.AddBindingRule<SecurityTokenValidationAttribute>();
             securityTokenValidationAttributeRule.Bind(inputBindingProvider);
 
             var signalRAttributeRule = context.AddBindingRule<SignalRAttribute>();
-            signalRAttributeRule.AddValidator(ValidateSignalRAttributeBinding);
             signalRAttributeRule.BindToCollector<SignalROpenType>(typeof(SignalRCollectorBuilder<>), options);
 
             logger.LogInformation("SignalRService binding initialized");
@@ -105,30 +101,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public Task<HttpResponseMessage> ConvertAsync(HttpRequestMessage input, CancellationToken cancellationToken)
         {
             return _dispatcher.ExecuteAsync(input, cancellationToken);
-        }
-
-        private void ValidateSignalRAttributeBinding(SignalRAttribute attribute, Type type)
-        {
-            ValidateConnectionString(
-                attribute.ConnectionStringSetting,
-                $"{nameof(SignalRAttribute)}.{nameof(SignalRAttribute.ConnectionStringSetting)}");
-        }
-
-        private void ValidateSignalRConnectionInfoAttributeBinding(SignalRConnectionInfoAttribute attribute, Type type)
-        {
-            ValidateConnectionString(
-                attribute.ConnectionStringSetting,
-                $"{nameof(SignalRConnectionInfoAttribute)}.{nameof(SignalRConnectionInfoAttribute.ConnectionStringSetting)}");
-        }
-
-        private void ValidateConnectionString(string attributeConnectionString, string attributeConnectionStringName)
-        {
-            var connectionString = Utils.FirstOrDefault(attributeConnectionString, options.ConnectionString);
-
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new InvalidOperationException(string.Format(ErrorMessages.EmptyConnectionStringErrorMessageFormat, attributeConnectionStringName));
-            }
         }
 
         private class SignalROpenType : OpenType.Poco

--- a/src/SignalRServiceExtension/Config/StaticServiceHubContextStore.cs
+++ b/src/SignalRServiceExtension/Config/StaticServiceHubContextStore.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     /// A global <see cref="IServiceManagerStore"/> for the extension.
     /// It stores <see cref="IServiceHubContextStore"/> per connection string.
     /// </summary>
-    internal static class StaticServiceHubContextStore
+    public static class StaticServiceHubContextStore
     {
         /// <summary>
         /// Gets <see cref="IServiceHubContextStore"/>. 

--- a/src/SignalRServiceExtension/Config/StaticServiceHubContextStore.cs
+++ b/src/SignalRServiceExtension/Config/StaticServiceHubContextStore.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     /// A global <see cref="IServiceManagerStore"/> for the extension.
     /// It stores <see cref="IServiceHubContextStore"/> per connection string.
     /// </summary>
-    public static class StaticServiceHubContextStore
+    internal static class StaticServiceHubContextStore
     {
         /// <summary>
         /// Gets <see cref="IServiceHubContextStore"/>. 
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         /// <param name="configurationKey"> is the connection string configuration key.</param>
         /// <returns>The returned value is an instance of <see cref="IServiceHubContextStore"/>.</returns>
         public static IServiceHubContextStore Get(string configurationKey = Constants.AzureSignalRConnectionStringName) =>
-            ServiceManagerStore.GetOrAddByConfigurationKey(configurationKey);
+            ServiceManagerStore.GetOrAddByConnectionStringKey(configurationKey);
 
         internal static IServiceManagerStore ServiceManagerStore { get; set; }
     }

--- a/src/SignalRServiceExtension/ErrorMessages.cs
+++ b/src/SignalRServiceExtension/ErrorMessages.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     internal static class ErrorMessages
     {
         public static readonly string EmptyConnectionStringErrorMessageFormat =
-            $"The SignalR Service connection string must be set either via an '{Constants.AzureSignalRConnectionStringName}' app setting, via an '{Constants.AzureSignalRConnectionStringName}' environment variable, or directly in code via {nameof(SignalROptions)}.{nameof(SignalROptions.ConnectionString)} or {{0}}.";
+            $"The SignalR Service connection string must be set under the key specified by ConnectionStringSetting.";
     }
 }

--- a/src/SignalRServiceExtension/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/src/SignalRServiceExtension/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="$(MicrosoftAzureSignalRManagement)" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="$(MicrosoftAzureFunctionsExtensionsVersion)" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)"/>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="$(MicrosoftAspNetCoreSignalRPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalRServiceExtension/SignalRAttribute.cs
+++ b/src/SignalRServiceExtension/SignalRAttribute.cs
@@ -10,10 +10,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     [Binding]
     public class SignalRAttribute : Attribute
     {
+        public string ConnectionStringSetting { get; set; } = Constants.AzureSignalRConnectionStringName;
 
-        [AppSetting(Default = Constants.AzureSignalRConnectionStringName)]
-        public string ConnectionStringSetting { get; set; }
-        
         [AutoResolve]
         public string HubName { get; set; }
     }

--- a/src/SignalRServiceExtension/SignalRConnectionInfoAttribute.cs
+++ b/src/SignalRServiceExtension/SignalRConnectionInfoAttribute.cs
@@ -12,8 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     [Binding]
     public class SignalRConnectionInfoAttribute : Attribute
     {
-        [AppSetting(Default = Constants.AzureSignalRConnectionStringName)]
-        public string ConnectionStringSetting { get; set; }
+        public string ConnectionStringSetting { get; set; } = Constants.AzureSignalRConnectionStringName;
 
         [AutoResolve]
         public string HubName { get; set; }

--- a/src/SignalRServiceExtension/Utils.cs
+++ b/src/SignalRServiceExtension/Utils.cs
@@ -12,12 +12,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             return values.FirstOrDefault(v => !string.IsNullOrEmpty(v));
         }
 
-        public static AzureSignalRClient GetAzureSignalRClient(string attributeConnectionString, string attributeHubName, SignalROptions options = null)
+        public static AzureSignalRClient GetAzureSignalRClient(string connectionStringKey, string attributeHubName, SignalROptions options = null)
         {
-            var connectionString = FirstOrDefault(attributeConnectionString, options?.ConnectionString);
             var hubName = FirstOrDefault(attributeHubName, options?.HubName);
 
-            return new AzureSignalRClient(StaticServiceHubContextStore.ServiceManagerStore, connectionString, hubName);
+            return new AzureSignalRClient(StaticServiceHubContextStore.ServiceManagerStore, connectionStringKey, hubName);
         }
     }
 }

--- a/test/SignalRServiceExtension.Tests/AzureSignalRClientTests.cs
+++ b/test/SignalRServiceExtension.Tests/AzureSignalRClientTests.cs
@@ -27,10 +27,11 @@ namespace SignalRServiceExtension.Tests
             var expectedName = "John Doe";
             var expectedIat = "1516239022";
             var claimTypeList = new string[] { "name", "iat" };
-            var configDict = new Dictionary<string, string>() { { Constants.ServiceTransportTypeName, "Transient" } };
+            var connectionStringKey = Constants.AzureSignalRConnectionStringName;
+            var configDict = new Dictionary<string, string>() { { Constants.ServiceTransportTypeName, "Transient" },{ connectionStringKey, connectionString } };
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
             var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance);
-            var azureSignalRClient = new AzureSignalRClient(serviceManagerStore, connectionString, hubName);
+            var azureSignalRClient = new AzureSignalRClient(serviceManagerStore, connectionStringKey, hubName);
             var connectionInfo = azureSignalRClient.GetClientConnectionInfo(userId, idToken, claimTypeList);
 
             Assert.Equal(connectionInfo.Url, $"{hubUrl}/client/?hub={hubName.ToLower()}");

--- a/test/SignalRServiceExtension.Tests/JobhostEndToEnd.cs
+++ b/test/SignalRServiceExtension.Tests/JobhostEndToEnd.cs
@@ -102,26 +102,26 @@ namespace SignalRServiceExtension.Tests
         [MemberData(nameof(SignalRConnectionInfoAttributeTestData))]
         public async Task ConnectionStringSettingFacts(Type classType, Dictionary<string, string> configDict)
         {
-                configDict[Constants.ServiceTransportTypeName] = nameof(ServiceTransportType.Transient);
+            configDict[Constants.ServiceTransportTypeName] = nameof(ServiceTransportType.Transient);
             _curConfigDict = configDict;
             await CreateTestTask(classType, configDict);
-            }
+        }
 
         [Fact]
         public async Task SignalRAttribute_MissingConnectionStringSettingFacts()
-            {
+        {
             var task = CreateTestTask(typeof(SignalRFunctionsWithoutConnectionString), null);
             var exception = await Assert.ThrowsAsync<FunctionInvocationException>(() => task);
             Assert.Equal(ErrorMessages.EmptyConnectionStringErrorMessageFormat, exception.InnerException.Message);
-            }
+        }
 
         [Fact]
         public async Task SignalRConnectionInfoAttribute_MissingConnectionStringSettingFacts()
-            {
+        {
             var task = CreateTestTask(typeof(SignalRConnectionInfoFunctionsWithoutConnectionString), null);
             var exception = await Assert.ThrowsAsync<FunctionInvocationException>(() => task);
             Assert.Equal(ErrorMessages.EmptyConnectionStringErrorMessageFormat, exception.InnerException.InnerException.Message);
-            }
+        }
 
         [Fact]
         [Obsolete]


### PR DESCRIPTION
* invokes SDK in a DI way, only gets `ServiceManagerStore` by connection string key.
* remove `[AppSetting]` attribute of `ConnectionStringSetting`  from `SignalRAttribute` and `SiganlRConnectionInfoAttribute`
