### PR TITLE
Support multiple Azure SignalR endpoints

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <MicrosoftAzureSignalRManagement>1.6.2-preview1-10693</MicrosoftAzureSignalRManagement>
+    <MicrosoftAzureSignalRManagement>1.7.0-preview1-10712</MicrosoftAzureSignalRManagement>
     <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>

--- a/src/SignalRServiceExtension/Client/AzureSignalRClient.cs
+++ b/src/SignalRServiceExtension/Client/AzureSignalRClient.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     internal class AzureSignalRClient : IAzureSignalRSender
     {
         public const string AzureSignalRUserPrefix = "asrs.u.";
+
         private static readonly string[] SystemClaims =
         {
             "aud", // Audience claim, used by service to make sure token is matched with target resource.
@@ -25,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             "iat", // Issued At claim. Added by default. It is not validated by service.
             "nbf"  // Not Before claim. Added by default. It is not validated by service.
         };
+
         private readonly IServiceManagerStore serviceManagerStore;
         private readonly string connectionStringKey;
 
@@ -45,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         public async Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(string userId, IList<Claim> claims)
         {
-            var serviceHubContext = (await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName) )as IInternalServiceHubContext;
+            var serviceHubContext = (await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName)) as IInternalServiceHubContext;
             var negotiateResponse = await serviceHubContext.NegotiateAsync(null, userId, BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList());
             return new SignalRConnectionInfo
             {
@@ -180,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                     // Add AzureSignalRUserPrefix if customer's claim name is duplicated with SignalR system claims.
                     // And split it when return from SignalR Service.
                     if (SystemClaims.Contains(claim.Type))
-                    { 
+                    {
                         yield return new Claim(prefix + claim.Type, claim.Value);
                     }
                     else

--- a/src/SignalRServiceExtension/Client/AzureSignalRClient.cs
+++ b/src/SignalRServiceExtension/Client/AzureSignalRClient.cs
@@ -7,6 +7,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Management;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 {
@@ -36,27 +37,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             this.connectionStringKey = connectionStringKey;
         }
 
-        public SignalRConnectionInfo GetClientConnectionInfo(string userId, string idToken, string[] claimTypeList)
+        public Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(string userId, string idToken, string[] claimTypeList)
         {
             var customerClaims = GetCustomClaims(idToken, claimTypeList);
-            var serviceManager = serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).ServiceManager;
-
-            return new SignalRConnectionInfo
-            {
-                Url = serviceManager.GetClientEndpoint(HubName),
-                AccessToken = serviceManager.GenerateClientAccessToken(
-                    HubName, userId, BuildJwtClaims(customerClaims, AzureSignalRUserPrefix).ToList())
-            };
+            return GetClientConnectionInfoAsync(userId, customerClaims);
         }
 
-        public SignalRConnectionInfo GetClientConnectionInfo(string userId, IList<Claim> claims)
+        public async Task<SignalRConnectionInfo> GetClientConnectionInfoAsync(string userId, IList<Claim> claims)
         {
-            var serviceManager = serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).ServiceManager;
+            var serviceHubContext = (await serviceManagerStore.GetOrAddByConnectionStringKey(connectionStringKey).GetAsync(HubName) )as IInternalServiceHubContext;
+            var negotiateResponse = await serviceHubContext.NegotiateAsync(null, userId, BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList());
             return new SignalRConnectionInfo
             {
-                Url = serviceManager.GetClientEndpoint(HubName),
-                AccessToken = serviceManager.GenerateClientAccessToken(
-                    HubName, userId, BuildJwtClaims(claims, AzureSignalRUserPrefix).ToList())
+                Url = negotiateResponse.Url,
+                AccessToken = negotiateResponse.AccessToken
             };
         }
 
@@ -186,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                     // Add AzureSignalRUserPrefix if customer's claim name is duplicated with SignalR system claims.
                     // And split it when return from SignalR Service.
                     if (SystemClaims.Contains(claim.Type))
-                    {
+                    { 
                         yield return new Claim(prefix + claim.Type, claim.Value);
                     }
                     else

--- a/src/SignalRServiceExtension/Config/IServiceHubContextStore.cs
+++ b/src/SignalRServiceExtension/Config/IServiceHubContextStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Management;
 
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     public interface IServiceHubContextStore
     {
         /// <summary>
-        /// Gets <see cref="IServiceHubContext"/>. 
+        /// Gets <see cref="IServiceHubContext"/>.
         /// If the <see cref="IServiceHubContext"/> for a specific hub name exists, returns the <see cref="IServiceHubContext"/>,
         /// otherwise creates one and then returns it.
         /// </summary>

--- a/src/SignalRServiceExtension/Config/IServiceHubContextStore.cs
+++ b/src/SignalRServiceExtension/Config/IServiceHubContextStore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.SignalR.Management;
 

--- a/src/SignalRServiceExtension/Config/OptionsSetup.cs
+++ b/src/SignalRServiceExtension/Config/OptionsSetup.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
+using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -38,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public void Configure(ServiceManagerOptions options)
         {
             options.ConnectionString = configuration[connectionStringKey];
+            options.ServiceEndpoints = configuration.GetEndpoints(connectionStringKey).ToArray();
             var serviceTransportTypeStr = configuration[Constants.ServiceTransportTypeName];
             if (Enum.TryParse<ServiceTransportType>(serviceTransportTypeStr, out var transport))
             {

--- a/src/SignalRServiceExtension/ErrorMessages.cs
+++ b/src/SignalRServiceExtension/ErrorMessages.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     internal static class ErrorMessages
     {
         public static readonly string EmptyConnectionStringErrorMessageFormat =
-            $"The SignalR Service connection string must be set under the key specified by ConnectionStringSetting.";
+            $"The SignalR Service connection strings must be set under the key specified by ConnectionStringSetting.";
     }
 }

--- a/src/SignalRServiceExtension/TriggerBindings/ServerlessHub.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/ServerlessHub.cs
@@ -68,22 +68,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public string HubName { get; }
 
         /// <summary>
-        /// Return a <see cref="SignalRConnectionInfo"/> to finish a client negotiation.
+        /// Gets client endpoint access information object for SignalR hub connections to connect to Azure SignalR Service
         /// </summary>
         [Obsolete("Please use async version instead.")]
-        protected SignalRConnectionInfo Negotiate(string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null, HttpContext httpContext = null)
+        protected SignalRConnectionInfo Negotiate(string userId = null, IList<Claim> claims = null, TimeSpan? lifetime = null, HttpContext httpContext = null)
         {
-            return NegotiateAsync(userId, claims, lifeTime, httpContext).Result;
+            return NegotiateAsync(userId, claims, lifetime, httpContext).Result;
         }
 
         /// <summary>
-        /// Return a <see cref="SignalRConnectionInfo"/> to finish a client negotiation.
+        /// Gets client endpoint access information object for SignalR hub connections to connect to Azure SignalR Service
         /// </summary>
-        protected async Task<SignalRConnectionInfo> NegotiateAsync(string userId = null, IList<Claim> claims = null, TimeSpan? lifeTime = null, HttpContext httpContext = null)
+        protected async Task<SignalRConnectionInfo> NegotiateAsync(string userId = null, IList<Claim> claims = null, TimeSpan? lifetime = null, HttpContext httpContext = null)
         {
             if (_hubContext != null)
             {
-                var negotiateResponse = await _hubContext.NegotiateAsync(httpContext, userId, claims, lifeTime);
+                var negotiateResponse = await _hubContext.NegotiateAsync(httpContext, userId, claims, lifetime);
                 return new SignalRConnectionInfo
                 {
                     Url = negotiateResponse.Url,
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
                 return new SignalRConnectionInfo
                 {
                     Url = _serviceManager.GetClientEndpoint(HubName),
-                    AccessToken = _serviceManager.GenerateClientAccessToken(HubName, userId, claims, lifeTime)
+                    AccessToken = _serviceManager.GenerateClientAccessToken(HubName, userId, claims, lifetime)
                 };
             }
         }

--- a/test/SignalRServiceExtension.Tests/AzureSignalRClientTests.cs
+++ b/test/SignalRServiceExtension.Tests/AzureSignalRClientTests.cs
@@ -5,10 +5,11 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using SignalRServiceExtension.Tests.Utils;
 using Xunit;
 
 namespace SignalRServiceExtension.Tests
@@ -16,7 +17,7 @@ namespace SignalRServiceExtension.Tests
     public class AzureSignalRClientTests
     {
         [Fact]
-        public void GetClientConnectionInfo()
+        public async Task GetClientConnectionInfo()
         {
             var hubName = "TestHub";
             var hubUrl = "http://localhost";
@@ -28,11 +29,11 @@ namespace SignalRServiceExtension.Tests
             var expectedIat = "1516239022";
             var claimTypeList = new string[] { "name", "iat" };
             var connectionStringKey = Constants.AzureSignalRConnectionStringName;
-            var configDict = new Dictionary<string, string>() { { Constants.ServiceTransportTypeName, "Transient" },{ connectionStringKey, connectionString } };
+            var configDict = new Dictionary<string, string>() { { Constants.ServiceTransportTypeName, "Transient" }, { connectionStringKey, connectionString } };
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
-            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance);
+            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, new TestRouter());
             var azureSignalRClient = new AzureSignalRClient(serviceManagerStore, connectionStringKey, hubName);
-            var connectionInfo = azureSignalRClient.GetClientConnectionInfo(userId, idToken, claimTypeList);
+            var connectionInfo = await azureSignalRClient.GetClientConnectionInfoAsync(userId, idToken, claimTypeList);
 
             Assert.Equal(connectionInfo.Url, $"{hubUrl}/client/?hub={hubName.ToLower()}");
 

--- a/test/SignalRServiceExtension.Tests/Config/ServiceManagerStoreTests.cs
+++ b/test/SignalRServiceExtension.Tests/Config/ServiceManagerStoreTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.SignalR.Common;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.SignalR.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace SignalRServiceExtension.Tests
+{
+    public class ServiceManagerStoreTests
+    {
+        [Fact]
+        public void GetServiceManager_WithSingleEndpoint()
+        {
+            var connectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var connectionStringKey = "key";
+            configuration[connectionStringKey] = connectionString;
+
+            var managerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, null);
+            var hubContextStore = managerStore.GetOrAddByConnectionStringKey(connectionStringKey);
+            var manager = hubContextStore.ServiceManager;
+        }
+
+        [Fact]
+        public void ProductInfoExists()
+        {
+            var connectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single();
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var connectionStringKey = "key";
+            configuration[connectionStringKey] = connectionString;
+
+            var productInfo = new ServiceCollection()
+                .AddSignalRServiceManager(new OptionsSetup(configuration, NullLoggerFactory.Instance, connectionStringKey))
+                .BuildServiceProvider()
+                .GetRequiredService<IOptions<ServiceManagerOptions>>()
+                .Value.ProductInfo;
+            Assert.NotNull(productInfo);
+        }
+
+        [Fact]
+        public async Task DefaultRouterExists()
+        {
+            var builder = new HostBuilder();
+            var host = builder
+                .ConfigureAppConfiguration(b => b.AddInMemoryCollection(new Dictionary<string, string> { {"key", FakeEndpointUtils.GetFakeConnectionString(1).Single()
+        } }))
+                .ConfigureWebJobs(b => b.AddSignalR()).Build();
+            var hubContext = await host.Services.GetRequiredService<IServiceManagerStore>().GetOrAddByConnectionStringKey("key").GetAsync("hubName") as IInternalServiceHubContext;
+            var exp = await Assert.ThrowsAsync<AzureSignalRException>(() => hubContext.NegotiateAsync());
+            Assert.IsType<AzureSignalRNotConnectedException>(exp.InnerException);
+        }
+    }
+}

--- a/test/SignalRServiceExtension.Tests/JobhostEndToEnd.cs
+++ b/test/SignalRServiceExtension.Tests/JobhostEndToEnd.cs
@@ -8,8 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Azure.SignalR.Common;
-using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.SignalR.Common; 
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Host;
@@ -62,30 +61,40 @@ namespace SignalRServiceExtension.Tests
             [Constants.AzureSignalRConnectionStringName] = DefaultConnectionString
         };
 
+        public static Dictionary<string, string> MultiConnStrOutsideOfAttrConfigDict = new Dictionary<string, string>
+        {
+            [AttrConnStrConfigKey] = DefaultAttributeConnectionString,
+            [AttrConnStrConfigKey + ":a"] = DefaultAttributeConnectionString,
+            [AttrConnStrConfigKey + ":b:primary"] = DefaultAttributeConnectionString
+        };
+
         public static Dictionary<string, string>[] TestConfigDicts = {
             ConnStrInsideOfAttrConfigDict,
             ConnStrOutsideOfAttrConfigDict,
             DiffConfigKeySameConnStrConfigDict,
             DiffConfigKeyDiffConnStrConfigDict,
             DiffConfigKeyDiffConnStrConfigDict,
+            MultiConnStrOutsideOfAttrConfigDict
         };
 
         public static Type[] TestClassTypesForSignalRAttribute =
         {
-            typeof(SignalRFunctionsWithConnectionString),
-            typeof(SignalRFunctionsWithoutConnectionString),
-            typeof(SignalRFunctionsWithConnectionString),
-            typeof(SignalRFunctionsWithConnectionString),
-            typeof(SignalRFunctionsWithMultipleConnectionStrings),
+            typeof(SignalRFunctionsWithCustomizedKey),
+            typeof(SignalRFunctions),
+            typeof(SignalRFunctionsWithCustomizedKey),
+            typeof(SignalRFunctionsWithCustomizedKey),
+            typeof(SignalRFunctionsWithMultiKeys),
+            typeof(SignalRFunctionsWithCustomizedKey),
         };
 
         public static Type[] TestClassTypesForSignalRConnectionInfoAttribute =
         {
-            typeof(SignalRConnectionInfoFunctionsWithConnectionString),
-            typeof(SignalRConnectionInfoFunctionsWithoutConnectionString),
-            typeof(SignalRConnectionInfoFunctionsWithConnectionString),
-            typeof(SignalRConnectionInfoFunctionsWithConnectionString),
-            typeof(SignalRConnectionInfoFunctionsWithMultipleConnectionStrings),
+            typeof(SignalRConnectionInfoFunctionsWithCustomizedKey),
+            typeof(SignalRConnectionInfoFunctions),
+            typeof(SignalRConnectionInfoFunctionsWithCustomizedKey),
+            typeof(SignalRConnectionInfoFunctionsWithCustomizedKey),
+            typeof(SignalRConnectionInfoFunctionsWithMultiKeys),
+            typeof(SignalRConnectionInfoFunctionsWithCustomizedKey),
         };
 
         public static IEnumerable<object[]> SignalRAttributeTestData => GenerateTestData(TestClassTypesForSignalRAttribute, TestConfigDicts);
@@ -102,7 +111,6 @@ namespace SignalRServiceExtension.Tests
         [MemberData(nameof(SignalRConnectionInfoAttributeTestData))]
         public async Task ConnectionStringSettingFacts(Type classType, Dictionary<string, string> configDict)
         {
-            configDict[Constants.ServiceTransportTypeName] = nameof(ServiceTransportType.Transient);
             _curConfigDict = configDict;
             await CreateTestTask(classType, configDict);
         }
@@ -110,7 +118,7 @@ namespace SignalRServiceExtension.Tests
         [Fact]
         public async Task SignalRAttribute_MissingConnectionStringSettingFacts()
         {
-            var task = CreateTestTask(typeof(SignalRFunctionsWithoutConnectionString), null);
+            var task = CreateTestTask(typeof(SignalRFunctions), null);
             var exception = await Assert.ThrowsAsync<FunctionInvocationException>(() => task);
             Assert.Equal(ErrorMessages.EmptyConnectionStringErrorMessageFormat, exception.InnerException.Message);
         }
@@ -118,7 +126,7 @@ namespace SignalRServiceExtension.Tests
         [Fact]
         public async Task SignalRConnectionInfoAttribute_MissingConnectionStringSettingFacts()
         {
-            var task = CreateTestTask(typeof(SignalRConnectionInfoFunctionsWithoutConnectionString), null);
+            var task = CreateTestTask(typeof(SignalRConnectionInfoFunctions), null);
             var exception = await Assert.ThrowsAsync<FunctionInvocationException>(() => task);
             Assert.Equal(ErrorMessages.EmptyConnectionStringErrorMessageFormat, exception.InnerException.InnerException.Message);
         }
@@ -210,7 +218,7 @@ namespace SignalRServiceExtension.Tests
         }
 
         #region SignalRAttributeTests
-        public class SignalRFunctionsWithConnectionString
+        public class SignalRFunctionsWithCustomizedKey
         {
             public async Task Func([SignalR(HubName = DefaultHubName, ConnectionStringSetting = AttrConnStrConfigKey)] IAsyncCollector<SignalRMessage> signalRMessages)
             {
@@ -219,7 +227,7 @@ namespace SignalRServiceExtension.Tests
             }
         }
 
-        public class SignalRFunctionsWithoutConnectionString
+        public class SignalRFunctions
         {
             public async Task Func([SignalR(HubName = DefaultHubName)] IAsyncCollector<SignalRMessage> signalRMessages)
             {
@@ -228,7 +236,7 @@ namespace SignalRServiceExtension.Tests
             }
         }
 
-        public class SignalRFunctionsWithMultipleConnectionStrings
+        public class SignalRFunctionsWithMultiKeys
         {
             public async Task Func1([SignalR(HubName = DefaultHubName, ConnectionStringSetting = Constants.AzureSignalRConnectionStringName)] IAsyncCollector<SignalRMessage> signalRMessages)
             {
@@ -245,7 +253,7 @@ namespace SignalRServiceExtension.Tests
         #endregion
 
         #region SignalRConnectionInfoAttributeTests
-        public class SignalRConnectionInfoFunctionsWithConnectionString
+        public class SignalRConnectionInfoFunctionsWithCustomizedKey
         {
             public void Func([SignalRConnectionInfo(UserId = DefaultUserId, HubName = DefaultHubName, ConnectionStringSetting = AttrConnStrConfigKey)] SignalRConnectionInfo connectionInfo)
             {
@@ -253,7 +261,7 @@ namespace SignalRServiceExtension.Tests
             }
         }
 
-        public class SignalRConnectionInfoFunctionsWithoutConnectionString
+        public class SignalRConnectionInfoFunctions
         {
             public void Func([SignalRConnectionInfo(UserId = DefaultUserId, HubName = DefaultHubName)] SignalRConnectionInfo connectionInfo)
             {
@@ -261,7 +269,7 @@ namespace SignalRServiceExtension.Tests
             }
         }
 
-        public class SignalRConnectionInfoFunctionsWithMultipleConnectionStrings
+        public class SignalRConnectionInfoFunctionsWithMultiKeys
         {
             public void Func1([SignalRConnectionInfo(UserId = DefaultUserId, HubName = DefaultHubName, ConnectionStringSetting = Constants.AzureSignalRConnectionStringName)] SignalRConnectionInfo connectionInfo)
             {

--- a/test/SignalRServiceExtension.Tests/Trigger/ServerlessHubTest.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/ServerlessHubTest.cs
@@ -1,9 +1,13 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
@@ -15,6 +19,7 @@ namespace SignalRServiceExtension.Tests.Trigger
     public class ServerlessHubTest
     {
         [Fact]
+        [Obsolete]
         private async Task ServerlessHubUnitTest()
         {
             var clientProxyMoc = new Mock<IClientProxy>();
@@ -46,11 +51,12 @@ namespace SignalRServiceExtension.Tests.Trigger
     public class MyHub : ServerlessHub
     {
         // Use default value = null to reconcile testing and production purpose.
-        public MyHub(IServiceHubContext serviceHubContext = null, IServiceManager serviceManager = null): base(serviceHubContext, serviceManager)
+        public MyHub(IServiceHubContext serviceHubContext = null, IServiceManager serviceManager = null) : base(serviceHubContext, serviceManager)
         {
         }
 
         [FunctionName("negotiate")]
+        [Obsolete]
         public SignalRConnectionInfo Negotiate(string userId)
         {
             return base.Negotiate(userId);

--- a/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerBindingProviderTests.cs
@@ -94,7 +94,7 @@ namespace SignalRServiceExtension.Tests
             var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             configuration[Constants.AzureSignalRConnectionStringName]= "Endpoint=http://localhost;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789;Version=1.0;";
             var dispatcher = new TestTriggerDispatcher();
-            return new SignalRTriggerBindingProvider(dispatcher, new DefaultNameResolver(new ConfigurationSection(new ConfigurationRoot(new List<IConfigurationProvider>()), String.Empty)), new ServiceManagerStore(configuration, NullLoggerFactory.Instance), exception);
+            return new SignalRTriggerBindingProvider(dispatcher, new DefaultNameResolver(new ConfigurationSection(new ConfigurationRoot(new List<IConfigurationProvider>()), String.Empty)), new ServiceManagerStore(configuration, NullLoggerFactory.Instance, null), exception);
         }
 
         public class TestServerlessHub : ServerlessHub

--- a/test/SignalRServiceExtension.Tests/Utils/FakeEndpointUtils.cs
+++ b/test/SignalRServiceExtension.Tests/Utils/FakeEndpointUtils.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.SignalR.Tests.Common
+{
+    public static class FakeEndpointUtils
+    {
+        public const string FakeAccessKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        public static IEnumerable<string> GetFakeConnectionString(int count)
+        {
+            return Enumerable.Range(0, count).Select(i => $"Endpoint=http://localhost{i};AccessKey={FakeAccessKey};Version=1.0;");
+        }
+
+        public static IEnumerable<ServiceEndpoint> GetFakeEndpoint(int count)
+        {
+            return GetFakeConnectionString(count).Select(connectionString => new ServiceEndpoint(connectionString));
+        }
+    }
+}

--- a/test/SignalRServiceExtension.Tests/Utils/TestHelpers.cs
+++ b/test/SignalRServiceExtension.Tests/Utils/TestHelpers.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Runtime.InteropServices.ComTypes;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.SignalR;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Host.Config;
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Constants = Microsoft.Azure.WebJobs.Extensions.SignalRService.Constants;
 
 namespace SignalRServiceExtension.Tests.Utils
 {
@@ -35,6 +36,7 @@ namespace SignalRServiceExtension.Tests.Utils
                 {
                     webJobsBuilder.AddSignalR();
                     webJobsBuilder.UseHostId(Guid.NewGuid().ToString("n"));
+                    webJobsBuilder.Services.AddSingleton<IEndpointRouter>(new TestRouter());
                 })
                 .ConfigureLogging(logging =>
                 {

--- a/test/SignalRServiceExtension.Tests/Utils/TestRouter.cs
+++ b/test/SignalRServiceExtension.Tests/Utils/TestRouter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.SignalR;
+
+namespace SignalRServiceExtension.Tests.Utils
+{
+    /// <summary>
+    /// A Router never throw exceptions even endpoints are offline.
+    /// </summary>
+    public class TestRouter : EndpointRouterDecorator
+    {
+        public override ServiceEndpoint GetNegotiateEndpoint(HttpContext context, IEnumerable<ServiceEndpoint> endpoints)
+        {
+            return endpoints.ElementAt(0);
+        }
+    }
+}


### PR DESCRIPTION
### Interface changes

1. `ServerlessHub`

    * Add `HttpContext` parameter to negotiate function.

    * Add async negotiate function 

2. Configuration

    * Support multiple endpoints configuration in the form consistent with Server SDK, see [document](https://github.com/Azure/azure-signalr/blob/dev/docs/sharding.md#how-to-add-multiple-endpoints-from-config). 

        ```
        AzureSignalRConnectionString =  ConnectionString0
        AzureSignalRConnectionString:east-region-a = <ConnectionString1>
        AzureSignalRConnectionString:backup:secondary = <ConnectionString3>
        ```

4.  Router customization. Users are allowed to add customized `IEndpointRouter` via C#.

    ```c#
        public class Startup : FunctionsStartup
        {
            public override void Configure(IFunctionsHostBuilder builder)
            {
                builder.Services.AddSingleton<IEndpointRouter,CustomizedRouter>();
            }
        }
    ```