### PR TITLE
Clarify missing AzureSignalRServiceTransportType error

### DIFF
--- a/src/SignalRServiceExtension/Config/OptionsSetup.cs
+++ b/src/SignalRServiceExtension/Config/OptionsSetup.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 options.ServiceTransportType = transport;
             }
+            else if (string.IsNullOrWhiteSpace(serviceTransportTypeStr)
+            {
+                options.ServiceTransportType = ServiceTransportType.Transient;
+                logger.LogWarning($"{Constants.ServiceTransportTypeName} not set, using default {ServiceTransportType.Transient} instead.");
+            }
             else
             {
                 options.ServiceTransportType = ServiceTransportType.Transient;

--- a/src/SignalRServiceExtension/Config/OptionsSetup.cs
+++ b/src/SignalRServiceExtension/Config/OptionsSetup.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 options.ServiceTransportType = transport;
             }
-            else if (string.IsNullOrWhiteSpace(serviceTransportTypeStr)
+            else if (string.IsNullOrWhiteSpace(serviceTransportTypeStr))
             {
                 options.ServiceTransportType = ServiceTransportType.Transient;
                 logger.LogWarning($"{Constants.ServiceTransportTypeName} not set, using default {ServiceTransportType.Transient} instead.");


### PR DESCRIPTION
When AzureSignalRServiceTransportType is unset, users get the log message `Unsupported service transport type: . Use default Transient instead.` which is confusing.

This clarifies it's using the default setting if not set.

