### PR TITLE
Add hub protocol configuration on netcore3.1

### DIFF
--- a/src/SignalRServiceExtension/Config/HubProtocol.cs
+++ b/src/SignalRServiceExtension/Config/HubProtocol.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#if NETCOREAPP3_1
+using Microsoft.AspNetCore.SignalR.Protocol;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal enum HubProtocol
+    {
+        /// <summary>
+        /// Implements the SignalR Hub Protocol using System.Text.Json.
+        /// <see cref="JsonHubProtocol"/>
+        /// </summary>
+        SystemTextJson,
+
+        /// <summary>
+        /// Implements the SignalR Hub Protocol using Newtonsoft.Json.
+        /// <see cref="NewtonsoftJsonHubProtocol "/>
+        /// </summary>
+        NewtonsoftJson
+    }
+}
+#endif

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -24,12 +24,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private readonly IConfiguration configuration;
         private readonly IEndpointRouter router;
         private readonly ConcurrentDictionary<string, IInternalServiceHubContextStore> store = new ConcurrentDictionary<string, IInternalServiceHubContextStore>();
+        private readonly ILogger<ServiceManagerStore> logger;
+        private const string hubProtocolWarning = "It's invalid to configure hub protocol on Azure Functions runtime V2. Newtonsoft.Json protocol will be used.";
 
         public ServiceManagerStore(IConfiguration configuration, ILoggerFactory loggerFactory, IEndpointRouter router = null)
         {
             this.loggerFactory = loggerFactory;
             this.configuration = configuration;
             this.router = router;
+            logger = this.loggerFactory.CreateLogger<ServiceManagerStore>();
         }
 
         public IInternalServiceHubContextStore GetOrAddByConnectionStringKey(string connectionStringKey)
@@ -66,10 +69,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 services.AddSingleton(router);
             }
-
+#if NETSTANDARD2_0
+            if (configuration[Constants.AzureSignalRHubProtocol] != null)
+            {
+                logger.LogWarning(hubProtocolWarning);
+            }
+#endif
 #if NETCOREAPP3_1
             var protocolStr = configuration.GetValue(Constants.AzureSignalRHubProtocol, HubProtocol.SystemTextJson);
-            if (protocolStr != HubProtocol.SystemTextJson)
+            if (protocolStr == HubProtocol.NewtonsoftJson)
             {
                 var jsonProtocols = services.Where(s => s.ServiceType == typeof(IHubProtocol) && s.ImplementationType == typeof(JsonHubProtocol)).ToArray();
                 foreach (var protocol in jsonProtocols)

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -66,13 +66,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 services.AddSingleton(router);
             }
+
 #if NETCOREAPP3_1
-            var jsonProtocols = services.Where(s => s.ServiceType == typeof(IHubProtocol) && s.ImplementationType == typeof(JsonHubProtocol)).ToArray();
-            foreach (var protocol in jsonProtocols)
+            var protocolStr = configuration.GetValue(Constants.AzureSignalRHubProtocol, HubProtocol.SystemTextJson);
+            if (protocolStr != HubProtocol.SystemTextJson)
             {
-                services.Remove(protocol);
+                var jsonProtocols = services.Where(s => s.ServiceType == typeof(IHubProtocol) && s.ImplementationType == typeof(JsonHubProtocol)).ToArray();
+                foreach (var protocol in jsonProtocols)
+                {
+                    services.Remove(protocol);
+                }
+                services.AddSingleton<IHubProtocol, NewtonsoftJsonHubProtocol>();
             }
-            services.AddSingleton<IHubProtocol, NewtonsoftJsonHubProtocol>();
 #endif
             services.AddSingleton(services.ToList() as IReadOnlyCollection<ServiceDescriptor>);
             return services.BuildServiceProvider()

--- a/src/SignalRServiceExtension/Constants.cs
+++ b/src/SignalRServiceExtension/Constants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         public const string AzureSignalRConnectionStringName = "AzureSignalRConnectionString";
         public const string AzureSignalREndpoints = "Azure:SignalR:Endpoints";
+        public const string AzureSignalRHubProtocol = "Azure:SignalR:HubProtocol";
         public const string ServiceTransportTypeName = "AzureSignalRServiceTransportType";
         public const string AsrsHeaderPrefix = "X-ASRS-";
         public const string AsrsConnectionIdHeader = AsrsHeaderPrefix + "Connection-Id";


### PR DESCRIPTION
The change that making newtonsoft the defalut protocol on netcore 3.1 is a breaking change.
Now restore the defalut protocol on netcore 3.1 to System.Text.Json and allow user to use `Azure:SignalR:HubProtocol` to configure it.
