### PR TITLE
Add hub protocol configuration on netcore3.1 (#187)

### DIFF
--- a/src/SignalRServiceExtension/Config/HubProtocol.cs
+++ b/src/SignalRServiceExtension/Config/HubProtocol.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#if NETCOREAPP3_1
+using Microsoft.AspNetCore.SignalR.Protocol;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    internal enum HubProtocol
+    {
+        /// <summary>
+        /// Implements the SignalR Hub Protocol using System.Text.Json.
+        /// <see cref="JsonHubProtocol"/>
+        /// </summary>
+        SystemTextJson,
+
+        /// <summary>
+        /// Implements the SignalR Hub Protocol using Newtonsoft.Json.
+        /// <see cref="NewtonsoftJsonHubProtocol "/>
+        /// </summary>
+        NewtonsoftJson
+    }
+}
+#endif

--- a/src/SignalRServiceExtension/Constants.cs
+++ b/src/SignalRServiceExtension/Constants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         public const string AzureSignalRConnectionStringName = "AzureSignalRConnectionString";
         public const string AzureSignalREndpoints = "Azure:SignalR:Endpoints";
+        public const string AzureSignalRHubProtocol = "Azure:SignalR:HubProtocol";
         public const string ServiceTransportTypeName = "AzureSignalRServiceTransportType";
         public const string AsrsHeaderPrefix = "X-ASRS-";
         public const string AsrsConnectionIdHeader = AsrsHeaderPrefix + "Connection-Id";


### PR DESCRIPTION
* Add hub protocol configuration on netcore3.1
* Add warning if HubProtocol is configured on Functions V2

The change that making newtonsoft the defalut protocol on netcore 3.1 is a breaking change.
Now restore the defalut protocol on netcore 3.1 to System.Text.Json and allow user to use `Azure:SignalR:HubProtocol` to configure it.