### PR TITLE
Append function_worker_runtime to product info

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <MicrosoftAzureSignalRManagement>1.8.1-preview1-10753</MicrosoftAzureSignalRManagement>
+    <MicrosoftAzureSignalRManagement>1.8.1-preview1-10754</MicrosoftAzureSignalRManagement>
     <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>

--- a/src/SignalRServiceExtension/Config/OptionsSetup.cs
+++ b/src/SignalRServiceExtension/Config/OptionsSetup.cs
@@ -58,11 +58,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
             //make connection more stable
             options.ConnectionCount = 3;
+            options.ProductInfo = GetProductInfo();
         }
 
         public IChangeToken GetChangeToken()
         {
             return configuration.GetReloadToken();
+        }
+
+        private string GetProductInfo()
+        {
+            var workerRuntime = configuration[Constants.FunctionsWorkerRuntime];
+            var sdkProductInfo = ProductInfo.GetProductInfo();
+            return $"{sdkProductInfo} [{Constants.FunctionsWorkerProductInfoKey}={workerRuntime}]";
         }
     }
 }

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private IInternalServiceHubContextStore CreateHubContextStore(string connectionStringKey)
         {
             var services = new ServiceCollection()
-                .WithAssembly(Assembly.GetExecutingAssembly())
                 .SetupOptions<ServiceManagerOptions, OptionsSetup>(new OptionsSetup(configuration, loggerFactory, connectionStringKey))
                 .PostConfigure<ServiceManagerOptions>(o =>
                 {

--- a/src/SignalRServiceExtension/Constants.cs
+++ b/src/SignalRServiceExtension/Constants.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         public const string OnDisconnected = "OnDisconnected";
 
         public const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
+        public const string FunctionsWorkerProductInfoKey = "func";
         public const string DotnetWorker = "dotnet";
     }
 


### PR DESCRIPTION
sample:  [func=dotnet]
sample for multiple properties: [func=dotnet, key=value]