### PR TITLE
 Remove the 'required' limitaion of group name

### DIFF
--- a/src/SignalRServiceExtension/Bindings/SignalRGroupAction.cs
+++ b/src/SignalRServiceExtension/Bindings/SignalRGroupAction.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         [JsonProperty("userId")]
         public string UserId { get; set; }
 
-        [JsonProperty("groupName"), JsonRequired]
+        [JsonProperty("groupName")]
         public string GroupName { get; set; }
 
         [JsonProperty("action"), JsonRequired]


### PR DESCRIPTION
fix https://github.com/Azure/azure-functions-signalrservice-extension/issues/217