### PR TITLE
Release 1.4.2

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <MicrosoftAzureSignalRManagement>1.8.1</MicrosoftAzureSignalRManagement>
+    <MicrosoftAzureSignalRManagement>1.8.2</MicrosoftAzureSignalRManagement>
     <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>

--- a/samples/chat-with-auth/README.md
+++ b/samples/chat-with-auth/README.md
@@ -112,17 +112,15 @@ Here is a diagram that illustrates the structure of this application:
    az functionapp config appsettings set --resource-group <resource_group_name> --name <function_name> \
       --setting AzureSignalRConnectionString=<signalr_connection_string>
    az functionapp config appsettings set --resource-group <resource_group_name> --name <function_name> \
-      --setting WebsiteHostName=<function_name>.azurewebsites.net
-   az functionapp config appsettings set --resource-group <resource_group_name> --name <function_name> \
       --setting FUNCTIONS_EXTENSION_VERSION=~2 
    ```
 
-> Note:  ```table_connection_string``` can be located in the Azure Portal from the Access Key section of the created storage account. ```blob_host``` is the blob service endpoint hostname (without https://), which you can find in the Blob Service Containers section. ```signalr_connection_string``` refers to the connection string you used before in the Chatroom sample.
+> Note:  ```blob_host``` is the blob service endpoint hostname (without https://), which you can find in the Blob Service Containers section. ```signalr_connection_string``` refers to the connection string you used before in the Chatroom sample.
 
 ## Conifigure Authentication
 
-1. In Azure portal, navigate to `Platform features/Authentication.`
-2. In `App Service Authentication`, click button `On`.
+1. In Azure portal, navigate to `Settings`
+2. In `Authentication (classic)`, click button `On`.
 3. Change `Action to take when request is not authenticated` list to `Log in with Azure Active Directory`.
 4. Configure AAD in `Azure Active Directory Settings`.
 5. Finally, click `Save`.

--- a/samples/chat-with-auth/csharp/FunctionApp/FunctionApp.csproj
+++ b/samples/chat-with-auth/csharp/FunctionApp/FunctionApp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.27" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\SignalRServiceExtension\Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj" />

--- a/samples/chat-with-custom-auth/csharp/FunctionApp/FunctionApp.csproj
+++ b/samples/chat-with-custom-auth/csharp/FunctionApp/FunctionApp.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\SignalRServiceExtension\Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj" />

--- a/samples/chat-with-custom-auth/csharp/FunctionApp/SignalRBindingSampleFunctions.cs
+++ b/samples/chat-with-custom-auth/csharp/FunctionApp/SignalRBindingSampleFunctions.cs
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Samples
 {
@@ -21,8 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Samples
             [SignalRConnectionInfo(HubName = Constants.HubName)] SignalRConnectionInfo connectionInfo)
         {
             return tokenResult.Status == SecurityTokenStatus.Valid
-                ? Task.FromResult(req.CreateResponse(HttpStatusCode.OK, connectionInfo))
-                : Task.FromResult(req.CreateErrorResponse(HttpStatusCode.Unauthorized, $"Validation result: {tokenResult.Status.ToString()}; Message: {tokenResult.Exception?.Message}"));
+                ? Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(connectionInfo) })
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new StringContent($"Validation result: {tokenResult.Status.ToString()}; Message: {tokenResult.Exception?.Message}") });
         }
 
         [FunctionName("messages")]

--- a/samples/chat-with-custom-auth/csharp/FunctionApp/local.settings.sample.json
+++ b/samples/chat-with-custom-auth/csharp/FunctionApp/local.settings.sample.json
@@ -6,10 +6,11 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "AzureSignalRConnectionString": "<signalr-connection-string>",
     "AzureSignalRServiceTransportType": "Transient",
-    "IssuerSigningKey": "<issuer-signing-key>"
+    "IssuerSigningKey": "bXlmdW5jdGlvbmF1dGh0ZXN0"
   },
   "Host": {
     "LocalHttpPort": 7071,
-    "CORS": "*"
+    "CORS": "http://127.0.0.1:8080",
+    "CORSCredentials": true
   }
 }

--- a/samples/simple-chat/csharp/FunctionApp/FunctionApp.csproj
+++ b/samples/simple-chat/csharp/FunctionApp/FunctionApp.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.30" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="3.0.14" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SignalRServiceExtension/TriggerBindings/ServerlessHub.cs
+++ b/src/SignalRServiceExtension/TriggerBindings/ServerlessHub.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             {
                 UserId = userId,
                 Claims = claims,
-                TokenLifetime = lifetime.GetValueOrDefault()
+                TokenLifetime = lifetime.GetValueOrDefault(TimeSpan.FromHours(1))
             }).Result;
         }
 

--- a/test/SignalRServiceExtension.Tests/Trigger/ServerlessHubTest.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/ServerlessHubTest.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Moq;
@@ -44,6 +46,15 @@ namespace SignalRServiceExtension.Tests.Trigger
             var message = Guid.NewGuid().ToString();
             await myHub.Broadcast(new InvocationContext(), target, message);
             clientProxyMoc.Verify(c => c.SendCoreAsync(target, It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ServerlessHubSyncNegotiate()
+        {
+            var hubContext = await new ServiceHubContextBuilder().WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single()).CreateAsync("hub", default);
+            var serviceManager = Mock.Of<IServiceManager>();
+            var myHub = new MyHub(hubContext, serviceManager);
+            var connectionInfo = myHub.Negotiate("user");
         }
     }
 


### PR DESCRIPTION
* Update Mgm SDK to 1.8.2, support Groups.Except(), All.Except() in transient mode.
* Fix a problem that exception is thrown when use ServerlessHub.Negotiate() without lifetime parameter(#239)