### PR TITLE
Support reading identity-based `ServiceEndpoint` from `Configuration`

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
-    <MicrosoftAzureSignalRManagement>1.9.1</MicrosoftAzureSignalRManagement>
+    <MicrosoftAzureSignalRManagement>1.11.0-preview1-10835</MicrosoftAzureSignalRManagement>
     <MicrosoftAzureFunctionsExtensionsVersion>1.0.0</MicrosoftAzureFunctionsExtensionsVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.9.0</MoqPackageVersion>

--- a/src/SignalRServiceExtension/Config/IConfigurationExtensions.cs
+++ b/src/SignalRServiceExtension/Config/IConfigurationExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Core;
+using Microsoft.Azure.SignalR;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    /// <summary>
+    /// A helper class to parse <see cref="ServiceEndpoint"/> from configuration.
+    /// </summary>
+    /// <remarks>
+    /// Copyied from https://github.com/Azure/azure-signalr/blob/e5a69b20daf7f7aa2786ff59df61433c4050c6ab/src/Microsoft.Azure.SignalR.Common/Endpoints/IConfigurationExtension.cs.
+    /// Although we have friend access to that internal class, referencing internal methods are not recommended as changes of internal methods might break this package.
+    /// </remarks>
+    internal static class IConfigurationExtensions
+    {
+        public static IEnumerable<ServiceEndpoint> GetEndpoints(this IConfiguration config, AzureComponentFactory azureComponentFactory)
+        {
+            foreach (IConfigurationSection child in config.GetChildren())
+            {
+                if (child.TryGetNamedEndpointFromIdentity(azureComponentFactory, out ServiceEndpoint endpoint))
+                {
+                    yield return endpoint;
+                    continue;
+                }
+
+                foreach (ServiceEndpoint item in child.GetNamedEndpointsFromConnectionString())
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        public static IEnumerable<ServiceEndpoint> GetNamedEndpointsFromConnectionString(this IConfigurationSection section)
+        {
+            string endpointName = section.Key;
+            if (section.Value != null)
+            {
+                yield return new ServiceEndpoint(section.Key, section.Value);
+            }
+
+            if (section["primary"] != null)
+            {
+                yield return new ServiceEndpoint(section["primary"], EndpointType.Primary, endpointName);
+            }
+
+            if (section["secondary"] != null)
+            {
+                yield return new ServiceEndpoint(section["secondary"], EndpointType.Secondary, endpointName);
+            }
+        }
+
+        public static bool TryGetNamedEndpointFromIdentity(this IConfigurationSection section, AzureComponentFactory azureComponentFactory, out ServiceEndpoint endpoint)
+        {
+            string text = section["ServiceUri"];
+            if (text != null)
+            {
+                string key = section.Key;
+                EndpointType value = section.GetValue("Type", EndpointType.Primary);
+                TokenCredential credential = azureComponentFactory.CreateTokenCredential(section);
+                endpoint = new ServiceEndpoint(new Uri(text), credential, value, key);
+                return true;
+            }
+
+            endpoint = null;
+            return false;
+        }
+    }
+}

--- a/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
+++ b/src/SignalRServiceExtension/Config/ServiceManagerStore.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Azure.SignalR;
 using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,13 +17,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     internal class ServiceManagerStore : IServiceManagerStore
     {
         private readonly ILoggerFactory loggerFactory;
+        private readonly AzureComponentFactory _azureComponentFactory;
         private readonly IConfiguration configuration;
         private readonly IEndpointRouter router;
         private readonly ConcurrentDictionary<string, IInternalServiceHubContextStore> store = new ConcurrentDictionary<string, IInternalServiceHubContextStore>();
 
-        public ServiceManagerStore(IConfiguration configuration, ILoggerFactory loggerFactory, IEndpointRouter router = null)
+        public ServiceManagerStore(IConfiguration configuration, ILoggerFactory loggerFactory, AzureComponentFactory azureComponentFactory, IEndpointRouter router = null)
         {
             this.loggerFactory = loggerFactory;
+            _azureComponentFactory = azureComponentFactory;
             this.configuration = configuration;
             this.router = router;
         }
@@ -46,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         private IInternalServiceHubContextStore CreateHubContextStore(string connectionStringKey)
         {
             var services = new ServiceCollection()
-                .SetupOptions<ServiceManagerOptions, OptionsSetup>(new OptionsSetup(configuration, loggerFactory, connectionStringKey))
+                .SetupOptions<ServiceManagerOptions, OptionsSetup>(new OptionsSetup(configuration, loggerFactory, _azureComponentFactory, connectionStringKey))
                 .PostConfigure<ServiceManagerOptions>(o =>
                 {
                     if ((o.ServiceEndpoints == null || o.ServiceEndpoints.Length == 0) && string.IsNullOrWhiteSpace(o.ConnectionString))

--- a/test/SignalRServiceExtension.Tests/AzureSignalRClientTests.cs
+++ b/test/SignalRServiceExtension.Tests/AzureSignalRClientTests.cs
@@ -38,7 +38,7 @@ namespace SignalRServiceExtension.Tests
             var connectionStringKey = Constants.AzureSignalRConnectionStringName;
             var configDict = new Dictionary<string, string>() { { Constants.ServiceTransportTypeName, "Transient" }, { connectionStringKey, connectionString } };
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
-            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, new TestRouter());
+            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, new TestRouter());
             var azureSignalRClient = await SignalRUtils.GetAzureSignalRClientAsync(connectionStringKey, hubName, serviceManagerStore);
             var connectionInfo = await azureSignalRClient.GetClientConnectionInfoAsync(userId, idToken, claimTypeList, null);
 

--- a/test/SignalRServiceExtension.Tests/Config/OptionsSetupFacts.cs
+++ b/test/SignalRServiceExtension.Tests/Config/OptionsSetupFacts.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.WebJobs.Extensions.SignalRService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace SignalRServiceExtension.Tests.Config
+{
+    public class OptionsSetupFacts
+    {
+        [Fact]
+        public void TestIdentityBasedSingleEndpointConfiguration()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var sectionKey = "connection";
+            var serviceUri = "http://localhost.signalr.com";
+            configuration[$"{sectionKey}:serviceUri"] = serviceUri;
+            var optionsSetup = new OptionsSetup(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, sectionKey);
+            var options = new ServiceManagerOptions();
+            optionsSetup.Configure(options);
+
+            var endpoint = Assert.Single(options.ServiceEndpoints);
+            Assert.Equal(serviceUri, endpoint.Endpoint);
+            Assert.Equal(string.Empty, endpoint.Name);
+        }
+
+        [Fact]
+        public void TestIdentityBasedMultiEndpointConfiguration()
+        {
+            var serviceUris = new string[] { "http://localhost.signalr.com", "http://localhost2.signalr.com" };
+            var endpointNames = new string[] { "eastus", "westus" };
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            configuration[$"Azure:SignalR:Endpoints:{endpointNames[0]}:serviceUri"] = serviceUris[0];
+            configuration[$"Azure:SignalR:Endpoints:{endpointNames[1]}:serviceUri"] = serviceUris[1];
+            var optionsSetup = new OptionsSetup(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, "does_not_matter");
+            var options = new ServiceManagerOptions();
+            optionsSetup.Configure(options);
+
+            Assert.Equal(2, options.ServiceEndpoints.Length);
+            Assert.Contains(options.ServiceEndpoints, e => endpointNames[0] == e.Name && serviceUris[0] == e.Endpoint);
+            Assert.Contains(options.ServiceEndpoints, e => endpointNames[1] == e.Name && serviceUris[1] == e.Endpoint);
+        }
+
+        /// <summary>
+        /// Test when named endpoints and nameless endpoint are configured, both should be included.
+        /// </summary>
+        [Fact]
+        public void TestIdentityBasedMixedEndpointConfiguration()
+        {
+            var serviceUris = new string[] { "http://localhost.signalr.com", "http://localhost2.signalr.com" };
+            var endpointName = "eastus";
+            var namelessEndpointKey = "AzureSignalRConnection";
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            configuration[$"Azure:SignalR:Endpoints:{endpointName}:serviceUri"] = serviceUris[0];
+            configuration[$"{namelessEndpointKey}:serviceUri"] = serviceUris[1];
+
+            var optionsSetup = new OptionsSetup(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, namelessEndpointKey);
+            var options = new ServiceManagerOptions();
+            optionsSetup.Configure(options);
+
+            Assert.Equal(2, options.ServiceEndpoints.Length);
+            Assert.Contains(options.ServiceEndpoints, e => endpointName == e.Name && serviceUris[0] == e.Endpoint);
+            Assert.Contains(options.ServiceEndpoints, e => string.Empty == e.Name && serviceUris[1] == e.Endpoint);
+        }
+    }
+}

--- a/test/SignalRServiceExtension.Tests/Config/ServiceManagerStoreTests.cs
+++ b/test/SignalRServiceExtension.Tests/Config/ServiceManagerStoreTests.cs
@@ -67,7 +67,7 @@ namespace SignalRServiceExtension.Tests
                             }))
                 .ConfigureWebJobs(b => b.AddSignalR()).Build();
             var hubContext = await host.Services.GetRequiredService<IServiceManagerStore>().GetOrAddByConnectionStringKey("key").GetAsync("hubName") as ServiceHubContext;
-            await Assert.ThrowsAsync<AzureSignalRNotConnectedException>(() => hubContext.NegotiateAsync());
+            await Assert.ThrowsAsync<AzureSignalRNotConnectedException>(() => hubContext.NegotiateAsync().AsTask());
         }
     }
 }

--- a/test/SignalRServiceExtension.Tests/Config/SingleAzureComponentFactory.cs
+++ b/test/SignalRServiceExtension.Tests/Config/SingleAzureComponentFactory.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SignalRServiceExtension.Tests
+{
+    public static class SingletonAzureComponentFactory
+    {
+        public static readonly AzureComponentFactory Instance;
+
+        static SingletonAzureComponentFactory()
+        {
+            var services = new ServiceCollection();
+            services.AddAzureClientsCore();
+            Instance = services.BuildServiceProvider().GetRequiredService<AzureComponentFactory>();
+        }
+    }
+}

--- a/test/SignalRServiceExtension.Tests/JobhostEndToEnd.cs
+++ b/test/SignalRServiceExtension.Tests/JobhostEndToEnd.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -138,7 +139,7 @@ namespace SignalRServiceExtension.Tests
             var builder = new HostBuilder();
             builder.ConfigureWebJobs(b =>
             {
-                b.AddSignalR();
+                b.AddSignalR().Services.AddAzureClientsCore();
             });
             var host = builder.Build();
             using (host)

--- a/test/SignalRServiceExtension.Tests/NegotiateContextAsyncConverterTest.cs
+++ b/test/SignalRServiceExtension.Tests/NegotiateContextAsyncConverterTest.cs
@@ -32,7 +32,7 @@ namespace SignalRServiceExtension.Tests
         public async Task EndpointsEqualFact()
         {
             var configuration = CreateTestConfiguration();
-            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance);
+            var serviceManagerStore = new ServiceManagerStore(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance);
             var converter = new NegotiationContextAsyncConverter(serviceManagerStore);
             var attribute = new SignalRNegotiationAttribute { HubName = HubName };
 

--- a/test/SignalRServiceExtension.Tests/Trigger/ServerlessHubTest.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/ServerlessHubTest.cs
@@ -51,7 +51,7 @@ namespace SignalRServiceExtension.Tests.Trigger
         [Fact]
         public async Task ServerlessHubSyncNegotiate()
         {
-            var hubContext = await new ServiceHubContextBuilder().WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single()).CreateAsync("hub", default);
+            var hubContext = await new ServiceManagerBuilder().WithOptions(o => o.ConnectionString = FakeEndpointUtils.GetFakeConnectionString(1).Single()).BuildServiceManager().CreateHubContextAsync("hub", default);
             var serviceManager = Mock.Of<IServiceManager>();
             var myHub = new MyHub(hubContext, serviceManager);
             var connectionInfo = myHub.Negotiate("user");

--- a/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerResolverTests.cs
+++ b/test/SignalRServiceExtension.Tests/Trigger/SignalRTriggerResolverTests.cs
@@ -18,10 +18,10 @@ namespace SignalRServiceExtension.Tests.Trigger
             var connectionId = "0f9c97a2f0bf4706afe87a14e0797b11";
             var accessKeys = new AccessKey[]
             {
-                new AccessKey("7aab239577fd4f24bc919802fb629f5f","http://endpoint1",1),
-                new AccessKey("a5f2815d0d0c4b00bd27e832432f91ab","http://endpont2",1)
+                new AccessKey("https://endpoint1", "7aab239577fd4f24bc919802fb629f5f"),
+                new AccessKey("https://endpont2", "a5f2815d0d0c4b00bd27e832432f91ab")
             };
-            var wrongAccessKeys = new AccessKey[] { new AccessKey(Guid.NewGuid().ToString(), "http://wrong", 1) };
+            var wrongAccessKeys = new AccessKey[] { new AccessKey("http://wrong", Guid.NewGuid().ToString()) };
             var signatures = new string[]
             {
                 "sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561",

--- a/test/SignalRServiceExtension.Tests/Utils/TestHelpers.cs
+++ b/test/SignalRServiceExtension.Tests/Utils/TestHelpers.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.SignalR;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,6 +32,7 @@ namespace SignalRServiceExtension.Tests.Utils
                         services.AddSingleton<IExtensionConfigProvider>(ext);
                     }
                     services.AddSingleton<IExtensionConfigProvider>(new TestExtensionConfig());
+                    services.AddAzureClientsCore();
                 })
                 .ConfigureWebJobs(webJobsBuilder =>
                 {


### PR DESCRIPTION
By default, we allow two styles to configure identity-based `ServiceEndpoint`: named endpoint and nameless endpoint. The key of nameless endpoint reuses `ConnectionStringSetting`. The key of named endpoints is "Azure:SignalR:Endpoints". The following is a sample.
```json
{
    "AzureSignalRConnectionString": {
        "serviceUri": "https://{SignalRHost}"
    },
    "Azure": {
        "SignalR": {
            "Endpoints": {
                "eastUs": {
                    "serviceUri": "https://{SignalRHost}"
                },
                "westUs": {
                    "serviceUri": "https://{SignalRHost}"
                }
            }
        }
    }
}
```
